### PR TITLE
Restructured pages on getting access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 build
 source/leuven/tier2_hardware/thinking_hardware/thinking_node_map_v2.pdf
 source/leuven/tier1_hardware/breniac_hardware/breniac_node_map.pdf
+
+# PDF documentation
+PdfDocs

--- a/source/access/account_request.rst
+++ b/source/access/account_request.rst
@@ -112,7 +112,7 @@ How?
 
 How to start?
 
--  Please follow the information on the webpage,
+-  Please follow the information on the documentation site,
 -  or register for the HPC Introduction course.
 -  If there is no course announced please register to ojjjjur `training
    waiting list`_ and we will organize a new session as soon as we get a few

--- a/source/access/account_request.rst
+++ b/source/access/account_request.rst
@@ -1,5 +1,3 @@
-.. _account request:
-
 Account request
 ===============
 
@@ -39,8 +37,10 @@ typing the passphrase when you use it.
 
 How to generate such a key pair, depends on your operating system. We
 describe the generation of key pairs in the client sections for
-:ref:`Linux<generating keys linux>`, :ref:`Windows <generating keys windows>`
-and :ref:`macOS<generating keys macos>` (formerly OS X).
+
+- :ref:`Linux<generating keys linux>`,
+- :ref:`Windows <generating keys windows>` and
+- :ref:`macOS<generating keys macos>` (formerly OS X).
 
 Without your key pair, you won't be able to apply for a VSC account.
 

--- a/source/access/generating_keys_with_openssh_on_os_x.rst
+++ b/source/access/generating_keys_with_openssh_on_os_x.rst
@@ -12,9 +12,10 @@ Terminal window and jump in! Because of this, you can use the same
 commands as specified in the on the ":ref:`generating keys linux`"
 section to access the cluster and transfer files.
 
+
 Generating a public/private key pair
 ------------------------------------
 
 Generating a public/private key pair is identical to what is described
-in the :ref:`linux client` section,
-that is, by using the ssh-keygen command in a Terminal window.
+for the :ref:`linux client <generating keys linux>`, that is, by using the ssh-keygen command
+in a Terminal window.

--- a/source/access/getting_access.rst
+++ b/source/access/getting_access.rst
@@ -1,11 +1,12 @@
 Getting access
 ==============
 
-The VSC account
----------------
+VSC accounts
+------------
 
 In order to use the infrastructure of the VSC, you need a VSC-userid,
-also called a VSC account.
+also called a VSC account.  Check the `VSC website <eligible users_>`_
+for conditions.
 
 All VSC-accounts start with the letters \\"vsc\" followed by a
 five-digit number. The first digit gives information about your home
@@ -13,69 +14,30 @@ institution. There is no relationship with your name, nor is the
 information about the link between VSC-accounts and your name publicly
 accessible.
 
+Your VSC account gives you access to most the VSC Tier-2 infrastructure, though
+for some more specialised hardware you have to ask access separately.
+The rationale is that  we want to ensure that that (usually rather expensive)
+hardware is used efficiently for the type of applications it was purchased for.
+Contact your :ref:`local VSC coordinator<get in touch_>`_ to arrange access
+when required.
 
-What can you access?
---------------------
-
-Your VSC account gives you access to the VSC Tier-2 infrastructure, though
-for some more specialised hardware you have to ask access separately, typically
-to the coordinator of your institution, because we want to be sure that that
-(usually rather expensive) hardware is used efficiently for the type of
-applications it was purchased for.
-
-You have disk space on the storage infrastructure that is accessible from
-all VSC infrastructure.
-
-For the main Tier-1 compute cluster you need to submit a project application
-(or you should be covered by a project application within your research group).
+For the main Tier-1 compute cluster you need to submit a
+`project application <tier-1 project application_>`_ (or you should be
+covered by a project application within your research group).
 
 
-Who can get a VSC account?
---------------------------
+.. _account request:
 
-Researchers at the Flemish university associations
-   In many cases, this is done through a fully automated application process,
-   but in some cases you must submit a request to your local support
-   team.
-Master students in the framework of their master thesis
-   If supercomputing is needed for the thesis. For this, you will first
-   need the approval of your supervisor. The details about the procedure
-   can again be found below.
-Use in courses at the University of Leuven and Hasselt University
-   Lecturers can also use the local Tier-2 infrastructure in the
-   context of some courses (when the software cannot run in the PC
-   classes or the computers in those classes are not powerful enough).
-   It is important that the application is submitted on
-   time, at least two weeks before the start of the computer sessions.
-Researchers from iMinds and VIB
-   The application is made through
-   your host university. The same applies to researchers at the
-   university hospitals and research institutes under the direction or
-   supervision of a university or a university college, such as the
-   special university institutes mentioned in Article 169quater of the
-   Decree of 12 June 1991 concerning universities in the Flemish
-   Community.
-Researchers at other Flemish public research institutions
-   You can get compute on the Tier-1 infrastructure through a project
-   application or access the Tier-2 infrastructure through contact with
-   one of the coordinators.
-Businesses, non-Flemish public knowledge institutions and not-for-profit organisations
-   These entities can buy compute time on the
-   infrastructure. The procedures are explained on the page
-   ":ref`buying compute time`".
-
-
-.. _account request
-How to request access?
-----------------------
+How to request an accout?
+-------------------------
 
 Unlike your institute account, VSC accounts don't use regular fixed
 passwords but a key pair consisting of a public an private key because
 that is a more secure authentication technique.  To apply for a VSC
 account, you need a public/private key pair.
 
-Public/private key pairs
-~~~~~~~~~~~~~~~~~~~~~~~~
+Create a public/private key pair
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A key pair consists of a private and a public key.
 
@@ -118,25 +80,7 @@ Applying for the account
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once you have a valid public/private key pair, you can submit an account
-request.
-
-For staff memebers and students of the universities and their
-associations, this can be d
-
-.. _generic access procedure:
-Generic procedure for academic researchers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For most researchers from the Flemish universities, the procedure has
-been fully automated and works by using your institute account to
-request a VSC account. Check below for exceptions or if the generic
-procedure does not work.
-
-Open the `VSC account page`_ and select your "home" institution. After
-you log in using your institution login and password, you will be asked
-to upload your public key. You will get an e-mail to confirm your application.
-After the account has been approved by the VSC, your account will be created
-and you will get a confirmation e-mail.
+request.  The following algorithm guides you to the appropriate approach.
 
 Users from the KU Leuven and UHasselt association
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -165,14 +109,6 @@ How?
       procedure for lecturers <lecturer procedure leuven>`,
       while the students should simply apply for the account through the
       :ref:`generic procedure <generic access procedure>`.
-
-How to start?
-
-   -  Please follow the information on the documentation site,
-   -  or register for the HPC Introduction course.
-   -  If there is no course announced please register to ojjjjur `training
-      waiting list`_ and we will organize a new session as soon as we get a few
-      people interested in it.
 
 Users of Ghent University Association
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -216,13 +152,52 @@ institute account. More information can be found on `this VUB Web
 Notes
 page <http://www.ulb.ac.be/wserv2_oratio/oratio?f_type=view&f_context=fiches&language=nl&noteid=227>`_.
 
-Troubleshooting
-~~~~~~~~~~~~~~~
+Everyone else
+^^^^^^^^^^^^^
 
-If you can't connect to the `VSC account page`_, some browser
-extensions have caused problems (and in particular some
-security-related extensions), so you might try with browser
-extensions disabled.
+Ask your VSC contact for help.  If you don't have a VSC contact yet, and
+`you are eligible to use VSC infrastructure <eligible users_>`_,
+please `get in touch`_ with us.
+
+
+.. _generic access procedure:
+
+Generic procedure for academic researchers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For most researchers from the Flemish universities, the procedure has
+been fully automated and works by using your institute account to
+request a VSC account. Check below for exceptions or if the generic
+procedure does not work.
+
+Open the `VSC account page`_ and select your "home" institution. After
+you log in using your institution login and password, you will be asked
+to upload your public key. You will get an e-mail to confirm your application.
+After the account has been approved by the VSC, your account will be created
+and you will get a confirmation e-mail.
+
+.. note::
+
+   If you can't connect to the `VSC account page`_ , some browser
+   extensions have caused problems (and in particular some
+   security-related extensions), so you might try with browser
+   extensions disabled.
+
+
+
+Next steps
+----------
+
+Register for an HPC Introduction course. These are organized at all universities
+on a regular basis.
+.. note:
+
+   For KU Leuven users: if there is no course announced please register to our `training
+   waiting list`_ and we will organize a new session as soon as we get a few
+   people interested in it.
+
+Information on our training program and the schedule is available on the
+`VSC website <VSC training_>`_.
 
 
 Additional information
@@ -240,18 +215,6 @@ infrastructure. You can find more detailed information in the user
 documentation on the user portal. When in doubt, you can also contact
 your local support team. This does not require a VSC account.
 
-Furthermore, it can also be useful to take one of the introductory
-courses that we organise periodically at all universities. However, it
-is best to apply for your VSC account before the course since you also
-can then also do the exercises during the course. We strongly urge
-people who are not familiar with the use of a Linux supercomputer to
-take such a course. After all, we do not have enough staff to help
-everyone individually for all those generic issues.
-
-There is an exception to the rule that you need a VSC account to access
-the VSC systems: Users with a valid VUB account can access the Tier-2
-systems at the VUB.
-
 Your account also includes two “blocks” of disk space: your home
 directory and data directory. Both are accessible from all VSC clusters.
 When you log in to a particular cluster, you will also be assigned one
@@ -265,3 +228,5 @@ development tools. For most commercial software, you must first prove
 that you have a valid license or the person who has paid the license on
 the cluster must allow you to use the license. For this you can contact
 your local support team.
+
+.. include:: links.rst

--- a/source/access/getting_access.rst
+++ b/source/access/getting_access.rst
@@ -14,20 +14,20 @@ information about the link between VSC-accounts and your name publicly
 accessible.
 
 
-
 What can you access?
 --------------------
-Your VSC account gives you access to most of the
-infrastructure, though only with a limited compute time allocation on
-some of the systems.
 
-Also, For the main Tier-1 compute cluster you need
-to submit a project application (or you should be covered by a project
-application within your research group). For some more specialised
-hardware you have to ask access separately, typically to the coordinator
-of your institution, because we want to be sure that that (usually
-rather expensive) hardware is used efficiently for the type of
+Your VSC account gives you access to the VSC Tier-2 infrastructure, though
+for some more specialised hardware you have to ask access separately, typically
+to the coordinator of your institution, because we want to be sure that that
+(usually rather expensive) hardware is used efficiently for the type of
 applications it was purchased for.
+
+You have disk space on the storage infrastructure that is accessible from
+all VSC infrastructure.
+
+For the main Tier-1 compute cluster you need to submit a project application
+(or you should be covered by a project application within your research group).
 
 
 Who can get a VSC account?
@@ -66,11 +66,8 @@ Businesses, non-Flemish public knowledge institutions and not-for-profit organis
 
 
 .. _account request
-
 How to request access?
 ----------------------
-
-Your VSC account is currently managed through your institute account.
 
 Unlike your institute account, VSC accounts don't use regular fixed
 passwords but a key pair consisting of a public an private key because
@@ -80,50 +77,53 @@ account, you need a public/private key pair.
 Public/private key pairs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-A key pair consists of a private and a public key. The private key is
-stored on the computer(s) from which you want to access the VSC and
-always stays there. The public key is stored on a the systems you want
-to access, granting access to the anyone who can prove to have access to
-the corresponding private key. Therefore it is very important to protect
-your private key, as anybody who has access to it can access your VSC
-account. For extra security, the private key itself should be encrypted
-using a 'passphrase', to prevent anyone from using your private key even
-when they manage to copy it. You have to 'unlock' the private key by
-typing the passphrase when you use it.
+A key pair consists of a private and a public key.
 
-How to generate such a key pair, depends on your operating system. We
+#. The private key is stored on the computer(s) you use to access the VSC
+   infrastructure and always stays there.
+#. The public key is stored on the  VSC systems you want to access, allowing
+   to prove your identity through the corresponding private key.
+  
+How to generate such a key pair depends on your operating system. We
 describe the generation of key pairs in the client sections for
 
 - :ref:`Linux<generating keys linux>`,
 - :ref:`Windows <generating keys windows>` and
 - :ref:`macOS<generating keys macos>` (formerly OS X).
 
-Without your key pair, you won't be able to apply for a VSC account.
+Without a key pair, you won't be able to apply for a VSC account.
 
-It is clear from the above that it is very important to protect your
-private key well. Therefore:
+.. warning::
 
--  You should not share your key pair with other users.
--  If you have accounts at multiple supercomputer centres (or on other
-   systems that use SSH), you should seriously consider using a
-   different key pair for each of those accounts. In that way, if a key
-   would get compromised, the damage can be controlled.
--  For added security, you may also consider to use a different key pair
-   for each computer you use to access your VSC account. If your
-   computer is stolen, it is then easy to disable access from that
-   computer while you can still access your VSC account from all your
-   other computers. The procedure is explained on a separate web
-   page ":ref:`access from multiple machines`".
+   It is clear from the above that it is very important to protect your
+   private key well. Therefore:
+   
+   - You should choose a strong passphrase to protect your private key.
+   - You should not share your key pair with other users.
+   - If you have accounts at multiple supercomputer centres (or on other
+     systems that use SSH), you should seriously consider using a
+     different key pair for each of those accounts. In that way, if a key
+     would get compromised, the damage can be controlled.
+   - For added security, you may also consider to use a different key pair
+     for each computer you use to access your VSC account. If your
+     computer is stolen, it is then easy to disable access from that
+     computer while you can still access your VSC account from all your
+     other computers. The procedure is explained on a separate web
+     page ":ref:`access from multiple machines`".
+
+Your VSC account is currently managed through your institute account.
+
 
 Applying for the account
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Depending on restrictions imposed by the institution, not all users
-might get a VSC account. We describe who can apply for an account in the
-sections of the local VSC clusters.
+Once you have a valid public/private key pair, you can submit an account
+request.
+
+For staff memebers and students of the universities and their
+associations, this can be d
 
 .. _generic access procedure:
-
 Generic procedure for academic researchers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -265,11 +265,3 @@ development tools. For most commercial software, you must first prove
 that you have a valid license or the person who has paid the license on
 the cluster must allow you to use the license. For this you can contact
 your local support team.
-
-
-Tier-1 applications
--------------------
-
-To prepare for a Tier-1 application, you can use ":ref:`Tier-1 application glossary`" of terms
-that are used in the application form, and check a :ref:`list of
-scientific domains`.

--- a/source/access/getting_access.rst
+++ b/source/access/getting_access.rst
@@ -12,8 +12,8 @@ to submit a project application (or you should be covered by a project
 application within your research group). For some more specialised
 hardware you have to ask access separately, typically to the coordinator
 of your institution, because we want to be sure that that (usually
-rather expensive hardware) is used efficiently for the type of
-applications for which it was purchased.
+rather expensive) hardware is used efficiently for the type of
+applications it was purchased for.
 
 Who can get a VSC account?
 --------------------------

--- a/source/access/getting_access.rst
+++ b/source/access/getting_access.rst
@@ -5,9 +5,23 @@ The VSC account
 ---------------
 
 In order to use the infrastructure of the VSC, you need a VSC-userid,
-also called a VSC account. The account gives you access to most of the
+also called a VSC account.
+
+All VSC-accounts start with the letters \\"vsc\" followed by a
+five-digit number. The first digit gives information about your home
+institution. There is no relationship with your name, nor is the
+information about the link between VSC-accounts and your name publicly
+accessible.
+
+
+
+What can you access?
+--------------------
+Your VSC account gives you access to most of the
 infrastructure, though only with a limited compute time allocation on
-some of the systems. Also, For the main Tier-1 compute cluster you need
+some of the systems.
+
+Also, For the main Tier-1 compute cluster you need
 to submit a project application (or you should be covered by a project
 application within your research group). For some more specialised
 hardware you have to ask access separately, typically to the coordinator
@@ -15,26 +29,23 @@ of your institution, because we want to be sure that that (usually
 rather expensive) hardware is used efficiently for the type of
 applications it was purchased for.
 
+
 Who can get a VSC account?
 --------------------------
 
 Researchers at the Flemish university associations
    In many cases, this is done through a fully automated application process,
    but in some cases you must submit a request to your local support
-   team. Specific details about these procedures can be found on the
-   ":ref:`account request`" page in the user documentation.
+   team.
 Master students in the framework of their master thesis
    If supercomputing is needed for the thesis. For this, you will first
    need the approval of your supervisor. The details about the procedure
-   can again be found on the ":ref:`account request`" page in the user
-   documentation.
+   can again be found below.
 Use in courses at the University of Leuven and Hasselt University
    Lecturers can also use the local Tier-2 infrastructure in the
    context of some courses (when the software cannot run in the PC
    classes or the computers in those classes are not powerful enough).
-   Again, you can find all the details about the application process on
-   the ":ref:`account request`" page in the user
-   documentation. It is important that the application is submitted on
+   It is important that the application is submitted on
    time, at least two weeks before the start of the computer sessions.
 Researchers from iMinds and VIB
    The application is made through
@@ -53,6 +64,167 @@ Businesses, non-Flemish public knowledge institutions and not-for-profit organis
    infrastructure. The procedures are explained on the page
    ":ref`buying compute time`".
 
+
+.. _account request
+
+How to request access?
+----------------------
+
+Your VSC account is currently managed through your institute account.
+
+Unlike your institute account, VSC accounts don't use regular fixed
+passwords but a key pair consisting of a public an private key because
+that is a more secure authentication technique.  To apply for a VSC
+account, you need a public/private key pair.
+
+Public/private key pairs
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+A key pair consists of a private and a public key. The private key is
+stored on the computer(s) from which you want to access the VSC and
+always stays there. The public key is stored on a the systems you want
+to access, granting access to the anyone who can prove to have access to
+the corresponding private key. Therefore it is very important to protect
+your private key, as anybody who has access to it can access your VSC
+account. For extra security, the private key itself should be encrypted
+using a 'passphrase', to prevent anyone from using your private key even
+when they manage to copy it. You have to 'unlock' the private key by
+typing the passphrase when you use it.
+
+How to generate such a key pair, depends on your operating system. We
+describe the generation of key pairs in the client sections for
+
+- :ref:`Linux<generating keys linux>`,
+- :ref:`Windows <generating keys windows>` and
+- :ref:`macOS<generating keys macos>` (formerly OS X).
+
+Without your key pair, you won't be able to apply for a VSC account.
+
+It is clear from the above that it is very important to protect your
+private key well. Therefore:
+
+-  You should not share your key pair with other users.
+-  If you have accounts at multiple supercomputer centres (or on other
+   systems that use SSH), you should seriously consider using a
+   different key pair for each of those accounts. In that way, if a key
+   would get compromised, the damage can be controlled.
+-  For added security, you may also consider to use a different key pair
+   for each computer you use to access your VSC account. If your
+   computer is stolen, it is then easy to disable access from that
+   computer while you can still access your VSC account from all your
+   other computers. The procedure is explained on a separate web
+   page ":ref:`access from multiple machines`".
+
+Applying for the account
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Depending on restrictions imposed by the institution, not all users
+might get a VSC account. We describe who can apply for an account in the
+sections of the local VSC clusters.
+
+.. _generic access procedure:
+
+Generic procedure for academic researchers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For most researchers from the Flemish universities, the procedure has
+been fully automated and works by using your institute account to
+request a VSC account. Check below for exceptions or if the generic
+procedure does not work.
+
+Open the `VSC account page`_ and select your "home" institution. After
+you log in using your institution login and password, you will be asked
+to upload your public key. You will get an e-mail to confirm your application.
+After the account has been approved by the VSC, your account will be created
+and you will get a confirmation e-mail.
+
+Users from the KU Leuven and UHasselt association
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+UHasselt has an agreement with KU Leuven to run a shared infrastructure.
+Therefore the procedure is the same for both institutions.
+
+Who?
+
+   Access is available for faculty, students (under faculty
+   supervision), and researchers of the KU Leuven, UHasselt and their
+   associations.
+
+How?
+
+   -  Researchers with a regular personnel account (u-number) can use
+      the :ref:`generic procedure <generic access procedure>`.
+   -  If you are in one of the higher education institutions associated
+      with KU Leuven, the :ref:`generic procedure <generic access procedure>`
+      may not work. In that case, please e-mail hpcinfo@kuleuven.be
+      to get an account. You will have to provide a public ssh key generated
+      as described above.
+   -  Lecturers of KU Leuven and UHasselt that need HPC access for giving
+      their courses: The procedure requires action both from the lecturers
+      and from the students. Lecturers should follow the :ref:`specific
+      procedure for lecturers <lecturer procedure leuven>`,
+      while the students should simply apply for the account through the
+      :ref:`generic procedure <generic access procedure>`.
+
+How to start?
+
+   -  Please follow the information on the documentation site,
+   -  or register for the HPC Introduction course.
+   -  If there is no course announced please register to ojjjjur `training
+      waiting list`_ and we will organize a new session as soon as we get a few
+      people interested in it.
+
+Users of Ghent University Association
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All information about the access policy is available `in
+English <https://www.ugent.be/hpc/en/policy>`_ at the `UGent
+HPC web pages <https://www.ugent.be/hpc>`_.
+
+-  Researchers can use the :ref:`generic procedure <generic access procedure>`.
+-  Master students can also use the infrastructure for their master
+   thesis work. The promotor of the thesis should first send a
+   motivation to hpc@ugent.be and then the :ref:`generic
+   procedure <generic access procedure>` should be followed (using your
+   student UGent id) to request the account.
+
+Users of the Antwerp University Association (AUHA)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Who?
+
+   Access ia available for faculty, students (master's projects under
+   faculty supervision), and researchers of the AUHA.
+
+How?
+
+-  Researchers of the University of Antwerp with a regular UAntwerpen
+   account can use the :ref:`generic procedure <generic access procedure>`.
+-  Users from higher education institutions associated with UAntwerpen
+   can get a VSC account via UAntwerpen. However, we have not yet set up
+   an automated form. Please contact the user support at
+   `hpc@uantwerpen.be <mailto:hpc@uantwerpen.be?subject=Account%20request>`_
+   to get an account. You will have to provide a public ssh key
+   generated as described above.
+
+Users of Brussels University Association
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you only need access to the VUB cluster Hydra, you don't
+necessarily need a full VSC account but can use your regular
+institute account. More information can be found on `this VUB Web
+Notes
+page <http://www.ulb.ac.be/wserv2_oratio/oratio?f_type=view&f_context=fiches&language=nl&noteid=227>`_.
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+If you can't connect to the `VSC account page`_, some browser
+extensions have caused problems (and in particular some
+security-related extensions), so you might try with browser
+extensions disabled.
+
+
 Additional information
 ----------------------
 
@@ -67,10 +239,6 @@ in this part of the website give a high-level description of our
 infrastructure. You can find more detailed information in the user
 documentation on the user portal. When in doubt, you can also contact
 your local support team. This does not require a VSC account.
-
-You should also first check the page ":ref:`account request`"
-and install the necessary software on your PC. You can also find links
-to information about that software on the “Account Request” page.
 
 Furthermore, it can also be useful to take one of the introductory
 courses that we organise periodically at all universities. However, it

--- a/source/access/getting_access.rst
+++ b/source/access/getting_access.rst
@@ -14,12 +14,12 @@ institution. There is no relationship with your name, nor is the
 information about the link between VSC-accounts and your name publicly
 accessible.
 
-Your VSC account gives you access to most of the VSC Tier-2 infrastructure, though
-for some more specialised hardware you may have to ask access separately.
-The rationale is that  we want to ensure that that (usually rather expensive)
-hardware is used efficiently for the type of applications it was purchased for.
-Contact your `local VSC coordinator <get in touch_>`_ to arrange access
-when required.
+Your VSC account gives you access to most of the VSC Tier-2 infrastructure,
+though for some more specialised hardware you may have to ask access separately.
+The rationale is that  we want to ensure that that specialised (usually rather
+expensive) hardware is used efficiently for the type of applications it was
+purchased for.  Contact your `local VSC coordinator <get in touch_>`_ to arrange
+access when required.
 
 For the main Tier-1 compute cluster you need to submit a
 `project application <tier-1 project application_>`_ (or you should be

--- a/source/access/getting_access.rst
+++ b/source/access/getting_access.rst
@@ -4,7 +4,7 @@ Getting access
 VSC accounts
 ------------
 
-In order to use the infrastructure of the VSC, you need a VSC-userid,
+In order to use the infrastructure of the VSC, you need a VSC-user ID,
 also called a VSC account.  Check the `VSC website <eligible users_>`_
 for conditions.
 
@@ -15,8 +15,8 @@ information about the link between VSC-accounts and your name publicly
 accessible.
 
 Your VSC account gives you access to most of the VSC Tier-2 infrastructure,
-though for some more specialised hardware you may have to ask access separately.
-The rationale is that  we want to ensure that that specialised (usually rather
+though for some more specialized hardware you may have to ask access separately.
+The rationale is that  we want to ensure that that specialized (usually rather
 expensive) hardware is used efficiently for the type of applications it was
 purchased for.  Contact your `local VSC coordinator <get in touch_>`_ to arrange
 access when required.
@@ -28,8 +28,8 @@ covered by a project application within your research group).
 
 .. _account request:
 
-How to request an accout?
--------------------------
+How to request an account?
+--------------------------
 
 Unlike your institute account, VSC accounts don't use regular fixed
 passwords but a key pair consisting of a public an private key because
@@ -64,7 +64,7 @@ Without a key pair, you won't be able to apply for a VSC account.
    
    - You should choose a strong passphrase to protect your private key.
    - You should not share your key pair with other users.
-   - If you have accounts at multiple supercomputer centres (or on other
+   - If you have accounts at multiple supercomputer centers (or on other
      systems that use SSH), you should seriously consider using a
      different key pair for each of those accounts. In that way, if a key
      would get compromised, the damage can be controlled.
@@ -131,7 +131,7 @@ Users of the Antwerp University Association (AUHA)
 
 Who?
 
-   Access ia available for faculty, students (master's projects under
+   Access is available for faculty, students (master's projects under
    faculty supervision), and researchers of the AUHA.
 
 How?

--- a/source/access/getting_access.rst
+++ b/source/access/getting_access.rst
@@ -36,6 +36,8 @@ passwords but a key pair consisting of a public an private key because
 that is a more secure authentication technique.  To apply for a VSC
 account, you need a public/private key pair.
 
+.. _create key pair:
+
 Create a public/private key pair
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -155,9 +157,14 @@ page <http://www.ulb.ac.be/wserv2_oratio/oratio?f_type=view&f_context=fiches&lan
 Everyone else
 ^^^^^^^^^^^^^
 
-Ask your VSC contact for help.  If you don't have a VSC contact yet, and
-`you are eligible to use VSC infrastructure <eligible users_>`_,
-please `get in touch`_ with us.
+Who?
+
+   Check that `you are eligible to use VSC infrastructure <eligible users_>`_,
+
+How?
+
+   Ask your VSC contact for help.  If you don't have a VSC contact yet, and please
+   `get in touch`_ with us.
 
 
 .. _generic access procedure:
@@ -170,11 +177,13 @@ been fully automated and works by using your institute account to
 request a VSC account. Check below for exceptions or if the generic
 procedure does not work.
 
-Open the `VSC account page`_ and select your "home" institution. After
-you log in using your institution login and password, you will be asked
-to upload your public key. You will get an e-mail to confirm your application.
-After the account has been approved by the VSC, your account will be created
-and you will get a confirmation e-mail.
+#. Open the `VSC account page`_.
+#. Select your "home" institution from the drop-down menu and click the "confirm" button.
+#. Log in using your institution login and password.
+#. You will be asked to upload the public key you `created earlier <create key pair_>`_.
+#. You will get an e-mail to confirm your application, click the included link to do so..
+#. After the account has been approved by the VSC, your account will be created and
+   you will get a confirmation e-mail.
 
 .. note::
 

--- a/source/access/links.rst
+++ b/source/access/links.rst
@@ -1,4 +1,8 @@
+.. _eligible users: https://www.vscentrum.be/getaccess
+.. _get in touch: https://www.vscentrum.be/getintouch
+.. _tier-1 project application: https://www.vscentrum.be/tier1
 .. _VSC account page: https://account.vscentrum.be/
+.. _VSC training: https://www.vscentrum.be/training
 .. _training waiting list: https://admin.kuleuven.be/icts/onderzoek/hpc/HPCintro-waitinglist
 .. _PuTTY: https://www.chiark.greenend.org.uk/~sgtatham/putty/
 .. _PuTTY download site: https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html


### PR DESCRIPTION
We noticed that it is currently too hard to find relevant info on the account request procedure.  Specifically, the pages on generating SSH keys are well hidden, and require three click-throughs.

* Eliminate one level of redirection.
* Emphasize procedural links.
* Link to information that is on the VSC website, eliminate duplication.

Feel free to comment.