### PR TITLE
Singularity documentation

### DIFF
--- a/source/access/getting_access.rst
+++ b/source/access/getting_access.rst
@@ -186,6 +186,11 @@ procedure does not work.
 #. After the account has been approved by the VSC, your account will be created and
    you will get a confirmation e-mail.
 
+.. warning::
+
+   Allow for at least half an hour for your account to be properly created
+   after receiving the confirmation email!
+
 .. note::
 
    If you can't connect to the `VSC account page`_ , some browser

--- a/source/faq.rst
+++ b/source/faq.rst
@@ -37,3 +37,14 @@ Running jobs
 
    jobs/why_doesn_t_my_job_start
    jobs/what_if_jobs_fail_after_starting_successfully
+
+
+.. _software faqs:
+
+Software
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   software/singularity.rst

--- a/source/software/links.rst
+++ b/source/software/links.rst
@@ -46,3 +46,5 @@
 .. _NAMD: http://www.ks.uiuc.edu/Research/namd/
 .. _TensorFlow: https://www.tensorflow.org/
 .. _CPMD: http://www.cpmd.org/
+.. _docker: https://www.docker.com/
+.. _Singularity: https://sylabs.io/singularity/

--- a/source/software/singularity.rst
+++ b/source/software/singularity.rst
@@ -108,7 +108,7 @@ Remote builds
 You can also build images on the Singularity website, and download
 them to the VSC infrastructure.  You will have to create an account
 at Sylabs.  Once this is done, you can use `Sylabs Remote Builder`_
-to create an image based on a :ref:`Singularity defintion 
+to create an image based on a :ref:`Singularity definition 
 <Singularity definition files>`.  If the build succeeds, you can
 pull the resulting image from the library::
 
@@ -139,7 +139,7 @@ some interactive setup is required.
 Singularity definition files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Below is an example of a Singularity defintion file::
+Below is an example of a Singularity definition file::
 
    Bootstrap: docker
    From: ubuntu:xenial
@@ -152,21 +152,21 @@ Below is an example of a Singularity defintion file::
        /usr/bin/grace
 
 The resulting image will be based on the Ubuntu Xenial Xerus distribution
-(18.04).  Once it is boostrapped, the command in the ``%post`` section of
+(18.04).  Once it is bootstrapped, the command in the ``%post`` section of
 the definition file will be executed.  For this example, the Grace plotting
 package will be installed.
 
 .. note::
 
    This example is intended to illustrate that very old software that
-   is no longer maintained can succesfully be run on modern infrastructure.
+   is no longer maintained can successfully be run on modern infrastructure.
    It is by no means intended to encourage you to start using Grace.
 
 Singularity definition files are very flexible, for more details,
-we refer you to the `Singularity defintion file documentation`_.
+we refer you to the `Singularity definition file documentation`_.
 
 An important advantage of definition files is that they can easily
-be sharedreproducibility.
+be shared, and improve reproducibility.
 
 
 How can I run a Singularity image?
@@ -179,7 +179,7 @@ Once you have an image, there are several options to run it.
 
    $ singularity  exec  grace.sif  xmgrace
 
-#. In case the defintion file specified a ``runscript``, this can be
+#. In case the definition file specified a ``runscript``, this can be
    executed using::
 
    $ singularity  run  grace.sif
@@ -241,7 +241,7 @@ For distributed applications it is highly recommended to use
 the same implementation and version of the MPI libraries on
 the host and in the image.  You also want to install the
 appropriate drivers for the interconnect, as well as the
-low-level communicaiton libraries, e.g., ibverbs.
+low-level communication libraries, e.g., ibverbs.
 
 For this type of scenario, it is probably best to contact :ref:`user
 support <user support VSC>`.
@@ -258,7 +258,7 @@ support <user support VSC>`.
 
 
 .. _Singularity installation documentation: https://sylabs.io/guides/3.2/user-guide/installation.html#
-.. _Singularity defintion file documentation: https://sylabs.io/guides/3.2/user-guide/definition_files.html
+.. _Singularity definition file documentation: https://sylabs.io/guides/3.2/user-guide/definition_files.html
 .. _Sylabs Remote Builder: https://cloud.sylabs.io/builder
 
 .. include:: links.rst

--- a/source/software/singularity.rst
+++ b/source/software/singularity.rst
@@ -1,0 +1,11 @@
+How can I run containers on the HPC systems?
+============================================
+
+The best-known container implementation is doubtlessly `docker`_.  However,
+due to security concerns HPC sites typically don't allow users to run
+Docker containers.
+
+Fortunately, `Singularity`_ addresses container related security issues,
+so Singularity images can be used on the cluster.
+
+.. include:: links.rst

--- a/source/software/singularity.rst
+++ b/source/software/singularity.rst
@@ -62,7 +62,7 @@ and has jupyter as well, use::
    where you have sufficient quota, e.g., ``$VSC_DATA``.
 
 
-This approach will serve you well when you can use either prebuild images
+This approach will serve you well when you can use either prebuilt images
 or docker containers.  If you need to modify an existing image or
 container, you should consider the alternatives.
 

--- a/source/software/singularity.rst
+++ b/source/software/singularity.rst
@@ -156,7 +156,7 @@ Below is an example of a Singularity definition file::
        /usr/bin/grace
 
 The resulting image will be based on the Ubuntu Xenial Xerus distribution
-(18.04).  Once it is bootstrapped, the command in the ``%post`` section of
+(16.04).  Once it is bootstrapped, the command in the ``%post`` section of
 the definition file will be executed.  For this example, the Grace plotting
 package will be installed.
 

--- a/source/software/singularity.rst
+++ b/source/software/singularity.rst
@@ -42,8 +42,8 @@ Building on VSC infrastructure
 
 Given that most build procedures require superuser privileges, your options
 on the VSC infrastructure are limited.  You can build an image from a docker
-container, e.g., to build an image that contains a version of tensorflow that
-can be used on GPUs, and has jupyter as well, use::
+container, e.g., to build an image that contains a version of TensorFlow 
+and has jupyter as well, use::
 
    $ export SINGULARITY_TMPDIR=$VSC_SCRATCH/singularity_tmp
    $ mkdir -p $SINGULARITY_TMPDIR

--- a/source/software/singularity.rst
+++ b/source/software/singularity.rst
@@ -22,7 +22,9 @@ typically built for the common denominator.
 Good use cases include:
 
 - Containers can be useful to run software that is hard to install
-  on HPC systems, e.g., GUI applications legacy software, and so on.
+  on HPC systems, e.g., GUI applications, legacy software, and so on.
+- Containers can be useful to deal with compatibility issues between
+  Linux flavors.
 - You want to create a workflow that can run on VSC infrastructure,
   but can also be burst to a third-party compute cloud (e.g., AWS
   or Microsoft Azure) when required.
@@ -62,7 +64,7 @@ and has jupyter as well, use::
    where you have sufficient quota, e.g., ``$VSC_DATA``.
 
 
-This approach will serve you well when you can use either prebuilt images
+This approach will serve you well if you can use either prebuilt images
 or docker containers.  If you need to modify an existing image or
 container, you should consider the alternatives.
 
@@ -105,7 +107,7 @@ it to the VSC infrastructure to use it.
 Remote builds
 ~~~~~~~~~~~~~
 
-You can also build images on the Singularity website, and download
+You can build images on the Singularity website, and download
 them to the VSC infrastructure.  You will have to create an account
 at Sylabs.  Once this is done, you can use `Sylabs Remote Builder`_
 to create an image based on a :ref:`Singularity definition 
@@ -127,7 +129,9 @@ pull the resulting image from the library::
    where you have sufficient quota, e.g., ``$VSC_DATA``.
 
 Remote builds have several advantages:
-- you only need a web browser to create them,
+
+- you only need a web browser to create them, so this approach is
+  platform-independent,
 - they can easily be shared with others.
 
 However, local builds still offer more flexibility, especially when
@@ -172,30 +176,37 @@ be shared, and improve reproducibility.
 How can I run a Singularity image?
 ----------------------------------
 
-Once you have an image, there are several options to run it.
+Once you have an image, there are several options to run the container.
 
-#. You can invoke any application that is in the PATH of the image, e.g.,
-   for the image containing Grace::
+#. You can invoke any application that is in the ``$PATH`` of the
+   container, e.g., for the image containing Grace::
 
    $ singularity  exec  grace.sif  xmgrace
 
-#. In case the definition file specified a ``runscript``, this can be
-   executed using::
+#. In case the definition file specified a ``%runscript`` directive,
+   this can be executed using::
 
    $ singularity  run  grace.sif
 
-#. The image can be run as a shell::
+#. The container can be run as a shell::
 
    $ singularity  shell  grace.sif
 
-By default, your home directory will be mounted with the same path
-as it has on the host.  The current working directory is that on
-the host in which you invoked ``singularity``.
+By default, your home directory in the container will be mounted
+with the same path as it has on the host.  The current working
+directory in the container is that on the host in which you
+invoked ``singularity``.
 
-Additional host directories can be mounted in the image as well by
-using the ``-B`` option.  Mount points are created dynamically, so
-they do not have to exist in the image.  For example, to mount the
-``$VSC_SCRATCH`` directory, you would use::
+.. note::
+
+   Although you can move to a parent directory of the current working
+   directory in the container, you will not see its contents on the host.
+   Only the current working directory on the host was mounted.
+
+Additional host directories can be mounted in the container as well by
+using the ``-B`` option.  Mount points are created dynamically (using
+overlays), so they do not have to exist in the image.  For example,
+to mount the ``$VSC_SCRATCH`` directory, you would use::
 
    $ singularity  exec  -B $VSC_SCRATCH:/scratch  grace.sif  xmgrace
 
@@ -211,14 +222,19 @@ image in the directory ``/scratch``.
 
       $ singularity  exec  -B $VSC_DATA:$VSC_DATA  grace.sif  xmgrace
 
-   The host environment variables are defined in the image.
+   Or, more concisely::
+
+      $ singularity  exec  -B $VSC_DATA  grace.sif  xmgrace
+
+   The host environment variables are defined in the image, hence
+   scripts that use those will work.
 
 
-Can I run singularity images in a job?
+Can I use singularity images in a job?
 --------------------------------------
 
 Yes, you can.  Singularity images can be part of any workflow, e.g.,
-the following script would create a plot::
+the following script would create a plot in the Grace container::
 
    #!/bin/bash –l
    #PBS –l nodes=1:ppn=1
@@ -228,7 +244,7 @@ the following script would create a plot::
    singularity exec grace.sif gracebat –data data.dat \
                                        -batch plot.bat
    
-Ensure that the image has access to all the required directories
+Ensure that the container has access to all the required directories
 by providing additional bindings if necessary.
 
 
@@ -245,6 +261,11 @@ low-level communication libraries, e.g., ibverbs.
 
 For this type of scenario, it is probably best to contact :ref:`user
 support <user support VSC>`.
+
+.. note::
+
+   For distributed application you may expect some mild performance
+   degradation.
 
 
 Can I run a service from a Singularity image?

--- a/source/software/singularity.rst
+++ b/source/software/singularity.rst
@@ -15,7 +15,7 @@ When should I use containers?
 -----------------------------
 
 If the software you intend to use is available on the VSC infrastructure,
-don't use containers.  This software has been build to use specific
+don't use containers.  This software has been built to use specific
 hardware optimizations, while software deployed via containers is
 typically built for the common denominator.
 

--- a/source/software/singularity.rst
+++ b/source/software/singularity.rst
@@ -11,6 +11,25 @@ image can be built from a docker container, that should not be a severe
 limitation.
 
 
+When should I use containers?
+-----------------------------
+
+If the software you intend to use is available on the VSC infrastructure,
+don't use containers.  This software has been build to use specific
+hardware optimizations, while software deployed via containers is
+typically built for the common denominator.
+
+Good use cases include:
+
+- Containers can be useful to run software that is hard to install
+  on HPC systems, e.g., GUI applications legacy software, and so on.
+- You want to create a workflow that can run on VSC infrastructure,
+  but can also be burst to a third-party compute cloud (e.g., AWS
+  or Microsoft Azure) when required.
+- You want to maximize the period your software can be run in a
+  reproducible way.
+
+
 How can I create a Singularity image?
 -------------------------------------
 

--- a/source/software/singularity.rst
+++ b/source/software/singularity.rst
@@ -201,7 +201,8 @@ invoked ``singularity``.
 
    Although you can move to a parent directory of the current working
    directory in the container, you will not see its contents on the host.
-   Only the current working directory on the host was mounted.
+   Only the current working directory and its sub-directories on the host
+   is mounted.
 
 Additional host directories can be mounted in the container as well by
 using the ``-B`` option.  Mount points are created dynamically (using

--- a/source/software/singularity.rst
+++ b/source/software/singularity.rst
@@ -6,6 +6,114 @@ due to security concerns HPC sites typically don't allow users to run
 Docker containers.
 
 Fortunately, `Singularity`_ addresses container related security issues,
-so Singularity images can be used on the cluster.
+so Singularity images can be used on the cluster.  Since a Singularity
+image can be built from a docker container, that should not be a severe
+limitation.
+
+
+How can I create an image?
+--------------------------
+
+You have three options to build images, locally on your  machine, in the
+cloud or on the VSC infrastructure.
+
+
+Building on VSC infrastructure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Given that most build procedures require superuser privileges, your options
+on the VSC infrastructure are limited.  You can build an image from a docker
+container, e.g., to build an image that contains a version of tensorflow that
+can be used on GPUs, and has jupyter as well, use::
+
+   $ export SINGULARITY_TMPDIR=$VSC_SCRATCH/singularity_tmp
+   $mkdir -p $SINGULARITY_TMPDIR
+   $ export SINGULARITY_CACHEDIR=$VSC_SCRATCH/singularity_cache
+   $mkdir -p $SINGULARITY_CACHEDIR
+   $ singularity build tensorflow.simg docker://tensorflow/tensorflow:latest-gpu-jupyter
+
+.. warning::
+
+   Don't forget to define and create the ``$SINGULARITY_TMPDIR`` and
+   ``$SINGULARITY_CACHEDIR`` since if you fail to do so, Singularity
+   will use directories in your home directory, and you will exceed
+   the quota on that file system.
+
+   Also, images tend to be very large, so store them on in a directory
+   where you have sufficient quota, e.g., ``$VSC_DATA``.
+
+
+This approach will serve you well when you can use either prebuild images
+or docker containers.  If you need to modify an existing image or
+container, you should consider the alternatives.
+
+.. note::
+
+   Creating image files may take considerable time and resources, it is good
+   practice to do this on a compute node, rather than on a login node.
+
+
+Local builds
+~~~~~~~~~~~~
+
+The most convenient way to create an image is on your own machine, since
+you will have superuser privileges, and hence the most options to chose
+from.  At this point, Singularity only runs under Linux, so you would
+to use a virtual machine when using Windows or MacOS.  For detailed
+instructions, see the `Singularity installation documentation`_.
+
+Besides building images from docker containers, you have the option to
+create them from a definition file, which allows you to completely customize
+your image.  We provide a brief :ref:`introduction to Singularity definition files
+<Singularity definition files>`, but for more details, we refer you to the
+`Singularity definition file documentation`_.
+
+When you have a Singularity definition file, e.g., ``my_image.def``, you can
+build your image file ``my_image.simg``::
+
+   $ singularity build my_image.simg my_image.def
+
+.. warning::
+
+   Since Singularity images can be very large, build your image
+   in a directory where you have sufficient quota, e.g.,
+   ``$VSC_DATA``.
+
+
+.. _Singularity definition files:
+
+Singularity definition files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below is an example of a Singularity defintion file::
+
+    BootStrap: docker
+    From: ubuntu:disco
+
+    %post
+        dpkg --add-architecture i386
+        apt-get update
+        apt-get install -y wine32
+        apt-get -y install wine
+        apt-get -y install winetricks
+
+The resulting image will be based on the Ubuntu Disco Dingo distribution (19.04).
+Once it is boostrapped, the command in the ``%post`` section of the definition
+file will be executed.  For this example, the wine Windows emulation software
+package will be installed.
+
+Singularity definition files are very flexible, for more details, we refer you
+to the `Singularity defintion file documentation`_.
+
+
+
+How to run a singularity container?
+-----------------------------------
+
+To do.
+
+
+.. _Singularity installation documentation: https://sylabs.io/guides/3.2/user-guide/installation.html#
+.. _Singularity defintion file documentation: https://sylabs.io/guides/3.2/user-guide/definition_files.html
 
 .. include:: links.rst


### PR DESCRIPTION
* Add documentation on how to use Singularity on the VSC infrastructure.

The information on how to build images is intentionally brief: there is no point in reproducing Sylabs' documentation and risking that ours is outdated after a short while.

Question: do all sites support Singularity, and more specifcally, Singularity 3.x?  If not, let me know, and I'll move this documentation to the Leuven specific part.