### PR TITLE
Fixed typos in (references to) labels

### DIFF
--- a/source/access/data_transfer_using_winscp.rst
+++ b/source/access/data_transfer_using_winscp.rst
@@ -18,8 +18,8 @@ PC.
 
 WinSCP also works together well with the PuTTY suite of applications. It
 uses the :ref:`keys generated with the PuTTY key generation
-program <generating keys on windows>`, can :ref:`launch terminal
-sessions in PuTTY <text access using PuTTY>` and :ref:`use
+program <generating keys windows>`, can :ref:`launch terminal
+sessions in PuTTY <text mode access using PuTTY>` and :ref:`use
 ssh keys managed by pageant <using Pageant>`.
 
 Transferring your files to and from the VSC clusters

--- a/source/access/how_to_create_manage_vsc_groups.rst
+++ b/source/access/how_to_create_manage_vsc_groups.rst
@@ -38,7 +38,7 @@ happens when you log on to a VSC cluster at a different site.
 Managing groups
 ---------------
 
-.. _viewing gropus:
+.. _viewing groups:
 
 Viewing the groups you belong to
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/access/setting_up_a_ssh_proxy.rst
+++ b/source/access/setting_up_a_ssh_proxy.rst
@@ -142,5 +142,5 @@ get more information about all the possibilities by issuing
 
    $ man 5 ssh_config
 
-Alternatively, you can also google on this line and find :ref:`copies of the
-manual page on the internet <http://www.manpagez.com/man/5/ssh_config/>`.
+Alternatively, you can also google on this line and find `copies of the
+manual page on the internet <http://www.manpagez.com/man/5/ssh_config/>`__.

--- a/source/access/text_mode_access_using_putty.rst
+++ b/source/access/text_mode_access_using_putty.rst
@@ -7,7 +7,7 @@ Prerequisite: PuTTY and WinSCP
 ------------------------------
 
 You've :ref:`generated a public/private key pair with PuTTY
-<generating keys PuTTY>` and have an approved account on the VSC clusters.
+<generating keys windows>` and have an approved account on the VSC clusters.
 
 Connecting to the VSC clusters
 ------------------------------

--- a/source/jobs/using_software.rst
+++ b/source/jobs/using_software.rst
@@ -9,7 +9,7 @@ particular cluster can be obtained by typing:
    $ module av
 
 In order to use those software packages, the user should work with the
-:ref:`module system <module-system-basics>`. On the newer
+:ref:`module system <module system basics>`. On the newer
 systems, we use the same naming conventions for packages on all systems.
 Due to the ever expanding list of packages, we've also made some
 adjustments and don't always show all packages, so be sure to check out
@@ -45,4 +45,5 @@ Packages with additional documentation
    administrator intervention. Some documentation for doing this for
    :ref:`Perl <Perl packages>` and :ref:`Python <Python packages>` is provided.
 
+.. include:: links.rst
 .. include:: ../software/links.rst

--- a/source/leuven/thinking7_quickstart.rst
+++ b/source/leuven/thinking7_quickstart.rst
@@ -1,7 +1,7 @@
 ThinKing7 quick start guide
 ===========================
 
-:ref:`ThinKing7 <thinking centos7 hardware>` is the old ThinKing cluster that got an upgrade to CentOS 7.6. The cluster is at the end of its lifetime. The Ivybridge nodes will be removed by the end of 2019. The Hasswell nodes have a little longer to go. ThinKing can be used for most workloads, but have a look at :ref:`Genius <Genius hardware>` for the most recent hardware.
+:ref:`ThinKing7 <thinking7 hardware>` is the old ThinKing cluster that got an upgrade to CentOS 7.6. The cluster is at the end of its lifetime. The Ivybridge nodes will be removed by the end of 2019. The Hasswell nodes have a little longer to go. ThinKing can be used for most workloads, but have a look at :ref:`Genius <Genius hardware>` for the most recent hardware.
 
 How to connect to ThinKing?
 ---------------------------
@@ -22,7 +22,7 @@ With a visualization capabilities (2 nvidia Quadro K5200 GPUs):
 - ``login7-tier2.hpc.kuleuven.be``
 - ``login8-tier2.hpc.kuleuven.be``
     
-For visualization nodes please refer to the :ref:`TurboVNC documentation <access/turbovnc_start_guide>`
+For visualization nodes please refer to the :ref:`TurboVNC documentation <TurboVNC start guide>`.
 
 Running jobs
 ------------
@@ -37,7 +37,7 @@ Remind that with migration to CentOS 7.6 toolchain starting from 2018a are avail
  
      module use /apps/leuven/haswell/2018a/modules/all
  
-ThinKing is now also using LMOD as module system. Have a look at  :ref:`Software stack <software/software_stack>` for more information.
+ThinKing is now also using Lmod as module system. Have a look at  :ref:`Software stack <Software stack>` for more information.
 
 There are several type of nodes in the ThinKing cluster: compute nodes with ivybridge or haswell processors and some gpu nodes. Have a look at the hardware pages for more information.
 

--- a/source/leuven/tier2_hardware/thinking_hardware.rst
+++ b/source/leuven/tier2_hardware/thinking_hardware.rst
@@ -1,7 +1,7 @@
 Thinking hardware
 =================
 
-Thinking is KU Leuven/UHasselt's older Tier-2 cluster. It has thin nodes, large memory nodes, as well as GPGPU nodes.  This cluster is still running CentOS 6, but is gradually being migrage to CentOS 7.  The migrated nodes are :ref:`available<Thinking CentOS 7 hardware>`.
+Thinking is KU Leuven/UHasselt's older Tier-2 cluster. It has thin nodes, large memory nodes, as well as GPGPU nodes.  This cluster is still running CentOS 6, but is gradually being migrage to CentOS 7.  The migrated nodes are :ref:`available<thinking7 hardware>`.
 
 
 Login infrastructure

--- a/source/software/intel_toolchain.rst
+++ b/source/software/intel_toolchain.rst
@@ -138,7 +138,7 @@ codes. Among other functionality, it offers:
    families
 
 For further documentation, we refer to :ref:`the links to the Intel
-documentation at the bottom of this page <Intel documentatino>`.
+documentation at the bottom of this page <Intel documentation>`.
 
 There are two ways to link the MKL library:
 


### PR DESCRIPTION
- remark: still issues with "lmod" in jobs/using_software.rst
  (see jobs/links.rst and gent/setting_up_the_environment_using_lmod_at_the_hpc_ugent_clusters.rst)
  and "open mpi" in software/mpi_for_distributed_programming.rst
  (see software/links.rst and software/foss_toolchain.rst)