### PR TITLE
Add FAQ page reference to landing page

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -15,5 +15,6 @@ Welcome to VSC documentation
    jobs/running_jobs
    software/software_development
    hardware
+   faq
 
 Feel free to contact :ref:`user support <user support VSC>`.


### PR DESCRIPTION
Proposal to add FAQ reference to landing page.  Refers to open issue #52 