### PR TITLE
Proxy page die, die, die

### DIFF
--- a/source/access/account_management.rst
+++ b/source/access/account_management.rst
@@ -25,7 +25,7 @@ Managing user credentials
       you can restore the keys on the cluster or upload a new key and
       then delete the old one.
 
-Group and Virtual Organisation management
+Group and Virtual Organization management
 -----------------------------------------
 
 Once your VSC account is active and you can log on to your home cluster,
@@ -45,14 +45,14 @@ clusters at KU Leuven).
       you feel you should belong to. It is then up to the moderator of
       that group to grant you membership.
    -  :ref:`create a new group <create groups>`
-   -  use group permissions to :ref:`control acces to files and
+   -  use group permissions to :ref:`control access to files and
       directories <permissions groups>`
 
 -  If you are a group moderator, you can manage your group by accepting
    requests from users that would like to join the group or inviting
    users to join your group through the `VSC account page`_.
 -  For UGent users only: You can create or join a so-called Virtual
-   Organisation or VO.
+   Organization or VO.
 
 Managing disk space
 -------------------
@@ -61,8 +61,8 @@ The amount of disk space that a user can use on the various file systems
 on the system is limited by quota on the amount of disk space and number
 of files. UGent users can see and request upgrades for their quota on
 the Account management site (Users need to be in a VO (Virtual
-Organisation) to request aditional quota. Creating and joining a VO is
-also done trought the Account Management website). On other sites
+Organization) to request additional quota. Creating and joining a VO is
+also done through the Account Management website). On other sites
 checking your disk space use is still :ref:`mostly done from the command
 line <disk usage>` and requesting more quote is done via email.
 

--- a/source/access/linux_client.rst
+++ b/source/access/linux_client.rst
@@ -40,10 +40,6 @@ The SSH configuration file ``.ssh/config`` can be used to :ref:`define
 connection properties<SSH config>` for nodes you often use.  It is a
 considerable time saver when working terminal-based.
 
-If you need to log in to a node protected by a firewall through another
-login node, you need to :ref:`setup an SSH proxy <proxy>` to log in to
-the protected node.
-
 To establish network communication between your local machine and the
 cluster otherwise blocked by firewalls, you have to :ref:`create an
 SSH tunnel using OpenSSH <tunnel OpenSSH>`.

--- a/source/access/setting_up_a_ssh_proxy.rst
+++ b/source/access/setting_up_a_ssh_proxy.rst
@@ -3,6 +3,14 @@
 Setting up a SSH proxy
 ======================
 
+.. warning::
+
+   If you simply want to configure PuTTY to connect to login nodes
+   of the VSC clusters, this is not the page you are looking for.
+   Please check out :ref:`how to configure PuTTY
+   <text mode access using PuTTY>`.
+
+
 Rationale
 ---------
 

--- a/source/access/setting_up_a_ssh_proxy.rst
+++ b/source/access/setting_up_a_ssh_proxy.rst
@@ -5,10 +5,9 @@ Setting up an SSH proxy
 
 .. warning::
 
-   If you simply want to configure PuTTY to connect to login nodes
+   If you simply want to use OpenSSH to connect to login nodes
    of the VSC clusters, this is not the page you are looking for.
-   Please check out :ref:`how to configure PuTTY
-   <text mode access using PuTTY>`.
+   Please check out :ref:`how to use the ssh command <OpenSSH access>`.
 
 
 Rationale

--- a/source/access/setting_up_a_ssh_proxy.rst
+++ b/source/access/setting_up_a_ssh_proxy.rst
@@ -1,7 +1,7 @@
 .. _proxy:
 
-Setting up a SSH proxy
-======================
+Setting up an SSH proxy
+=======================
 
 .. warning::
 

--- a/source/access/setting_up_a_ssh_proxy_with_putty.rst
+++ b/source/access/setting_up_a_ssh_proxy_with_putty.rst
@@ -1,7 +1,7 @@
 .. _ssh proxy with PuTTY:
 
-Setting up a SSH proxy with PuTTY
-=================================
+Setting up an SSH proxy with PuTTY
+==================================
 
 .. warning::
 

--- a/source/access/setting_up_a_ssh_proxy_with_putty.rst
+++ b/source/access/setting_up_a_ssh_proxy_with_putty.rst
@@ -3,6 +3,14 @@
 Setting up a SSH proxy with PuTTY
 =================================
 
+.. warning::
+
+   If you simply want to configure PuTTY to connect to login nodes
+   of the VSC clusters, this is not the page you are looking for.
+   Please check out :ref:`how to configure PuTTY
+   <text mode access using PuTTY>`.
+
+
 Rationale
 ---------
 

--- a/source/access/setting_up_a_ssh_proxy_with_putty.rst
+++ b/source/access/setting_up_a_ssh_proxy_with_putty.rst
@@ -33,8 +33,24 @@ so-called *ssh proxy*. You then connect through another computer (the
 This all sounds quite complicated, but once things are configured
 properly it is really simple to log on to the host.
 
+
 Setting up a proxy in PuTTY
 ---------------------------
+
+.. warning::
+
+   In the screenshots, we show the proxy setup for user ``vscXXXXX`` to
+   the ``login.muk.gent.vsc`` login node for the muk cluster at UGent
+   via the login node ``vsc.login.node``.
+   You will have to
+
+   #. replace ``vscXXXXX`` with your own VSC account, and
+   #. replace ``login.muk.gent.vsc`` by the node that is behind a
+      a firewall that you want to acces, and
+   #. find the name of the login node for the cluster you want
+      to use use as a proxy in the sections of :ref:`the local VSC
+      clusters <hardware>`, and replace ``vsc.login.node`` accordingly.
+
 
 Setting up the connection in PuTTY is a bit more complicated than for a
 simple direct connection to a login node.

--- a/source/access/text_mode_access_using_putty.rst
+++ b/source/access/text_mode_access_using_putty.rst
@@ -16,16 +16,17 @@ When you start the PuTTY executable 'putty.exe', a configuration screen
 pops up. Follow the steps below to setup the connection to (one of) the
 VSC clusters.
 
-In the screenshots, we show the setup for user vsc98765 to the ThinKing
-cluster at KU Leuven via the login node login.hpc.kuleuven.be.
+.. warning::
 
-You can find the names and ip-addresses of the login nodes in the
-sections of :ref:`the local VSC clusters <hardware>`.
+   In the screenshots, we show the setup for user ``vsc98765`` to the
+   genius cluster at KU Leuven via the login node ``login.hpc.kuleuven.be``.
+   You will have to
 
-| Alternatively, you can follow a `short
-  video <https://www.vscentrum.be/assets/1191>`__ explaining
-  step-by-step the process of making connection to VSC login nodes
-  (example based on KU Leuven cluster).
+   #. replace ``vsc98765`` with your own VSC number, and
+   #. find the name of the login node for the cluster you want
+      to login in on in the sections on :ref:`the local VSC clusters
+      <hardware>`, and replace ``login.hpc.kuleuven.be`` accordingly.
+
 
 #. Within the category Session, in the field 'Host Name', type in
    <vsc-loginnode>, which is the name of the login node of the VSC
@@ -42,8 +43,11 @@ sections of :ref:`the local VSC clusters <hardware>`.
    |PuTTY config 2|
 
    Here, the private key was previously saved in the folder
-   "C:\\Documents and Settings\\Me\\Keys". In newer versions of Windows,
-   "C:\\Users" is used instead of "C:\\Documents and Settings".
+   ``C:\Users\Me\Keys``. In older versions of Windows, you would have
+   to use ``C:\Documents and Settings\Me\Keys``.
+   
+   You can also enable agent forwarding by ticking the 'Allow agent
+   forwarding' checkbox.
 #. In the category Connection > SSH > X11, click the Enable X11
    Forwarding checkbox:
 

--- a/source/access/text_mode_access_using_putty.rst
+++ b/source/access/text_mode_access_using_putty.rst
@@ -22,7 +22,7 @@ VSC clusters.
    genius cluster at KU Leuven via the login node ``login.hpc.kuleuven.be``.
    You will have to
 
-   #. replace ``vsc98765`` with your own VSC number, and
+   #. replace ``vsc98765`` with your own VSC user name, and
    #. find the name of the login node for the cluster you want
       to login in on in the sections on :ref:`the local VSC clusters
       <hardware>`, and replace ``login.hpc.kuleuven.be`` accordingly.

--- a/source/access/windows_client.rst
+++ b/source/access/windows_client.rst
@@ -27,15 +27,11 @@ the :ref:`NX client for Windows<NX start guide>` so that you don't need
 to enter the passphrase all the time.  Pageant is part of the `PuTTY`_
 distribution.
 
-To log on to a node protected by a firewall through another login node,
-you need to :ref:`set up an SSH
-proxy with PuTTY <ssh proxy with PuTTY>`.
-
-To establish network communication between your local machine and the
-cluster otherwise blocked by firewalls you have to :ref:`create an SSH
-tunnel using PuTTY <ssh tunnel using PuTTY>` .  This is also useful to run
-client software on your Windows machine, e.g., ParaView or Jupyter
-notebooks that run on a compute node.
+To establish network communication between your local machine and a compute
+node of a cluster you have to :ref:`create an SSH tunnel using PuTTY
+<ssh tunnel using PuTTY>` .  This is also useful to run client software
+on your Windows machine, e.g., ParaView or Jupyter notebooks that run on
+a compute node.
 
 
 Transfer data using Secure FTP (SFTP) clients


### PR DESCRIPTION
The pages on configuring PuTTY and (to a lesser degree) OpenSSH to use a proxy cause quite some confusion for novice users, resulting in helpdesk tickets.

The references to the pages on configuring PuTTY and OpenSSH to use proxies have been removed, although the pages themselves still exist.

Explicit warnings have been added to the pages that contain screenshots on what has to be modified for the specific user/cluster.

A remark on switching on agent forwarding when configuring PuTTY has been added.