### PR TITLE
Add remark on terminal login to NX login hosts

### DIFF
--- a/source/leuven/tier2_hardware/genius_login_nodes.rst
+++ b/source/leuven/tier2_hardware/genius_login_nodes.rst
@@ -17,7 +17,7 @@ Two types of login nodes are available:
   - ``login4-tier2.hpc.kuleuven.be``
 
 - login node that provides a desktop environment that can be used for,
-  e.g., visualization, see the :ref:`NX clients section <NX start guide>1:
+  e.g., visualization, see the :ref:`NX clients section <NX start guide>`:
 
   - ``nx.hpc.kuleuven.be``
 


### PR DESCRIPTION
Although users can login using SSH to the NX nodes (nx.hpc.kuleuven.be and nx-tier1.hpc.kuleuven.be) they shouldn't.  These nodes simply route the login using the NX client to the appropriate login nodes of either genius or breniac.