### PR TITLE
Add quick start for Breniac

### DIFF
--- a/source/jobs/credit_system_basics.rst
+++ b/source/jobs/credit_system_basics.rst
@@ -111,6 +111,13 @@ all transactions on all accounts the user has access to::
    $ module load accounting
    $ mam-statement
 
+.. note::
+
+   It takes quite a while to compute such statements, so **please
+   be patient**.  If you simply want a list of the transaction,
+   consider using ``mam-list-transactions``, this is typically
+   much faster.
+
 However, it is more convenient to filter this information so that only
 specific projects are displayed and/or information for a specific period
 of time, e.g.,
@@ -122,15 +129,16 @@ of time, e.g.,
 This will show the transactions on the account for the
 ``lp_astrophysics_014`` project for the month September 2010.
 
-.. note::
+If you are only interested in the individual transaction, and don't require
+balance information, ``mam-list-transactions`` provides a much faster
+alternative::
 
-   It takes quite a while to compute such statements, so **please
-   be patient**.
+   $ mam-list-transactions  -a lp_astrophysics_014  -s 2010-09-01  -e 2010-09-30
 
-Very useful can be adding the ``--summarize`` option to the ``gstatement``
+It can be Very useful to add the ``--summarize`` option to the ``mam-statement``
 command::
 
-   vsc30002@login1:~> mam-statement -a lp_prodproject --summarize -s 2010-09-01 -e 2010-09-30
+   $ mam-statement  -a lp_prodproject  --summarize  -s 2010-09-01  -e 2010-09-30
    ################################################################################
    #
    # Statement for project lp_prodproject
@@ -157,9 +165,10 @@ command::
    Job    Charge lp_prodproject      vsc30140 SVCS1    -0.22 1
    ############################### End of Report ##################################
 
-As you can see it will give you a summary of used credits (Amount) and
+As you can see it will give you a summary of credits used (Amount) and
 number of jobs (Count) per user in a given time frame for a specified
 project.
+
 
 Reviewing job details
 ---------------------
@@ -170,7 +179,7 @@ the details of a specific job. This can be done using the following
 command::
 
    $ module load accounting
-   $ mam-list-transactions -J 20030021
+   $ mam-list-transactions  -J 20030021
 
 Where job ID does not have to be complete.
 

--- a/source/jobs/credit_system_basics.rst
+++ b/source/jobs/credit_system_basics.rst
@@ -3,10 +3,15 @@
 Credit system basics
 ====================
 
+VSC infrastructure hosted by KU Leuven uses a credit system, so if you want
+to use this infrastructure, you will need :ref:`access to a credit account
+<Credits to use KU Leuven infrastructure>`.
+
+
 Introduction
 ------------
 
-The accounting system on ThinKing is very similar to a regular bank.
+The accounting system is very similar to a regular bank.
 Individual users have accounts that will be charged for the jobs they
 run. However, the number of credits on such accounts is fairly small, so
 research projects will typically have one or more project accounts
@@ -14,39 +19,13 @@ associated with them. Users that are project members can have their
 project-related jobs charged to such a project account. In this how-to,
 the technical aspects of accounting are explained.
 
-How to request credits on the KU Leuven Tier-2 systems
-------------------------------------------------------
-
-You can request 2 types of job credits: introduction credits and project
-credits. **Introduction credits** are a limited amount of free credits
-for test and development purposes. **Project credits** are job credits
-used for research.
-
-How to request introduction credits
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can find all relevant information in the `Service Catalog`_ (login required).
-
-How to request project credits
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can find all relevant information in the `Service Catalog`_ (login required).
-
-Prices
-~~~~~~
-
-All details about prices you can find in the `Service Catalog`_ (login required).
-
 Checking an account balance
 ---------------------------
 
 Since no calculations can be done without credits, it is quite useful to
 determine the amount of credits at your disposal. This can be done quite
-easily:
+easily::
 
-::
-
-   $ module load accounting
    $ mam-balance
 
 This will provide an overview of the balance on the user's personal
@@ -56,37 +35,48 @@ Obtaining a job quote
 ---------------------
 
 In order to determine the cost of a job, the user can request a quote.
-The gquote commands takes those options as the qsub command that are
+The ``gquote`` commands takes those options as the ``qsub`` command that are
 relevant for resource specification (-l, -q, -C), and/or, the PBS script
 that will be used to run the job. The command will calculate the maximum
 cost based on the resources that are requested, taking into account
-walltime, number of compute nodes and node type.
-
-::
+walltime, number of compute nodes and node type::
 
    $ module load accounting
-   $ gquote -q qlong -l nodes=3:ppn=20:ivybridge
+   $ gquote  -l walltime=5:00:00  -l nodes=3:ppn=36
+
+The resources can be specified either on the command line as in the example
+above, in the job script, or in both.  Just like for ``qsub``, the
+specifications on the command line take priority over those in the
+job script::
+
+   $ module load accounting
+   $ gquote  -l walltime=5:00:00  myjob.pbs
+
+In this case, the number of nodes and the node type will be derived from
+the specification in ``myjob.pbs``.
 
 Details of how to tailor job requirements can be found on the page on
 ":ref:`resource specification`".
 
-Note that when a queue is specified and no explicit walltime, the
-walltime used to produce the quote is the longest walltime allowed by
-that queue. Also note that unless specified by the user, gquote will
-assume the most expensive node type. This implies that the cost
-calculated by gquote will always be larger than the effective cost that
-is charged when the job finishes.
+.. note::
+
+   ``gquote`` will always show the maximum amount of credits your job
+   can be charged.  For instance, if no node type is specified, ``gquote``
+   assumes your job will run on the most expensive one.
+
+   Obviously, ``gquote`` only provides a quote, you will be charged for
+   the actual resource usage, not the requested resources.
+
 
 Running jobs: accounting workflow
 ---------------------------------
 
 When a job is submitted using ``qsub``
 and it has to be charged against a project account, the name of the
-project has to be specified as an option. In case of the introduction credits the project account should be specified as  ``default_project``
+project has to be specified as an option. In case of the introduction
+credits the project account should be specified as  ``default_project``::
 
-::
-
-   $ qsub -A lp_astrophysics_014 run-job.pbs
+   $ qsub  -A lp_astrophysics_014  run-job.pbs
 
 If the account to be charged, i.e., ``lp_astrophysics_014``, has insufficient
 credits for the job, the user receives a warning at this point.
@@ -95,9 +85,9 @@ Just prior to job execution, a reservation will be made on the specified
 project's account, or the user's personal account if no project was
 specified. When the user checks her balance at this point, she will
 notice that it has been decreased with an amount equal to, or less than
-that provided by gquote. The latter may occur when the node type is
+that provided by ``gquote``. The latter may occur when the node type is
 determined when the reservation is made, and the node type is less
-expensive than that assumed by gquote. If the relevant account has
+expensive than that assumed by ``gquote``. If the relevant account has
 insufficient credits at this point, the job will be deleted from the
 queue.
 
@@ -105,8 +95,9 @@ When the job finishes, the account will effectively be charged. The
 balance of that account will be equal or larger after charging. The
 latter can occur when the job has taken less walltime than the
 reservation was made for. This implies that although quotes and
-reservations may be overestimations, users will only be charged for the
+reservations may be overestimated, users will only be charged for the
 resources their jobs actually consumed.
+
 
 Obtaining an overview of transactions
 -------------------------------------
@@ -115,9 +106,7 @@ A bank provides an overview of the financial transactions on your
 accounts under the form of statements. Similarly, the job accounting
 system provides statements that give the user an overview of the cost of
 each individual job. The following command will provide an overview of
-all transactions on all accounts the user has access to:
-
-::
+all transactions on all accounts the user has access to::
 
    $ module load accounting
    $ mam-statement
@@ -128,18 +117,18 @@ of time, e.g.,
 
 ::
 
-   $ mam-statement -a lp_astrophysics_014 -s 2010-09-01 -e 2010-09-30
+   $ mam-statement  -a lp_astrophysics_014  -s 2010-09-01  -e 2010-09-30
 
 This will show the transactions on the account for the
 ``lp_astrophysics_014`` project for the month September 2010.
 
-Note that it takes quite a while to compute such statements, so **please
-be patient**.
+.. note::
 
-Very useful can be adding the '--summarize' option to the 'gstatement'
-command:
+   It takes quite a while to compute such statements, so **please
+   be patient**.
 
-::
+Very useful can be adding the ``--summarize`` option to the ``gstatement``
+command::
 
    vsc30002@login1:~> mam-statement -a lp_prodproject --summarize -s 2010-09-01 -e 2010-09-30
    ################################################################################
@@ -169,7 +158,7 @@ command:
    ############################### End of Report ##################################
 
 As you can see it will give you a summary of used credits (Amount) and
-number of jobs (Count) per user in a given timeframe for a specified
+number of jobs (Count) per user in a given time frame for a specified
 project.
 
 Reviewing job details
@@ -178,85 +167,22 @@ Reviewing job details
 A statement is an overview of transactions, but provides no details on
 the resources the jobs consumed. However, the user may want to examine
 the details of a specific job. This can be done using the following
-command:
-
-::
+command::
 
    $ module load accounting
    $ mam-list-transactions -J 20030021
 
 Where job ID does not have to be complete.
 
-Job cost calculation
---------------------
+.. note:
 
-The cost of a job depends on the resources it consumes. Generally
-speaking, one credit buys the user one hour of walltime on one reference
-node. The resources that are taken into account to charge for a job are
-the walltime it consumed, and the number and type of compute nodes it
-ran on. The following formula is used:
+   Charging is done for the number of compute nodes used by the
+   job, not the number of cores. This implies that a single core job on a
+   single node is as expensive as an 36 core job on the same single node.
+   The rationale is that the scheduler instates a single user per node
+   policy. Hence using a single core on a node blocks all other cores for
+   other users' jobs. If a user needs to run many single core jobs
+   concurrently, she is advised to use the :ref:`worker framework`.
 
-0.000278 \* *nodes* \* *walltime* \* *nodetype*
-
-Where,
-
--  *nodes* is the number of compute nodes the job ran on;
--  *walltime* the effective duration of the job, expressed in seconds;
--  *nodetype* is the factor representing the node type's performance as
-   listed in the table below.
-
-Since Tier-2 cluster has several types of compute nodes, none of which
-is actually a reference node, the following values for *nodetype* apply:
-
-+------------+-------------+
-| node type  | credit/hour |
-+============+=============+
-| Ivy Bridge | 4.76        |
-+------------+-------------+
-| Haswell    | 6.68        |
-+------------+-------------+
-| Skylake    | 10.00       |
-+------------+-------------+
-| GPU        | 2.86        |
-+------------+-------------+
-| Cerebro    | 3.45        |
-+------------+-------------+
-
-The difference in cost between different machines/processors reflects
-the performance difference between those types of nodes. The total cost
-of a job will typically be the same on any compute nodes, but the
-walltime will be different nodes. It is considerably more expensive to
-work on Cerebro since it has a large amount of memory, as well as local
-disk, and hence required a larger investment.
-
-An example of a job running on multiple nodes and cores is given below:
-
-::
-
-   $ qsub -A lp_astrophysics_014 -lnodes=2:ppn=20:ivybridge simulation_3415.pbs
-
-If this job finished in 2.5 hours (i.e., walltime is 9000), the user
-will be charged:
-
-0.000278 \* 2 \* 9000 \* 4.76 = 23.8 credits
-
-For a single node, single core job that also took 2.5 hours and was
-submitted as:
-
-::
-
-   $ qsub -A lp_astrophysics_014 -lnodes=1:ppn=1:ivybridge simulation_147.pbs
-
-In this case, the user will be charged:
-
-0.000278 \* 1 \* 9000 \* 4.76 = 11.9 credits
-
-Note that charging is done for the number of compute nodes used by the
-job, not the number of cores. This implies that a single core job on a
-single node is as expensive as an 20 core job on the same single node.
-The rationale is that the scheduler instates a single user per node
-policy. Hence using a single core on a node blocks all other cores for
-other users' jobs. If a user needs to run many single core jobs
-concurrently, she is advised to use the :ref:`worker framework`.
 
 .. include:: links.rst

--- a/source/leuven/breniac_quickstart.rst
+++ b/source/leuven/breniac_quickstart.rst
@@ -155,6 +155,13 @@ is done by specifying the ``singleisland`` feature::
    $ qsub -l nodes=20:ppn=28  -l walltime=2:00:00  -l feature=singleisland \
           -A myproject  myjobscript.pbs
 
+Similarly, if your job runs on less than 68 nodes (broadwell), or
+48 nodes (skylake) you can request that all nodes the job runs on are
+in the same rack. This is done by specifying the ``singlerack`` feature::
+
+   $ qsub -l nodes=40:ppn=28  -l walltime=2:00:00  -l feature=singlerack \
+          -A myproject  myjobscript.pbs
+
 
 Running on specific nodes/islands
 ---------------------------------

--- a/source/leuven/breniac_quickstart.rst
+++ b/source/leuven/breniac_quickstart.rst
@@ -1,0 +1,96 @@
+Breniac quick start
+===================
+
+:ref:`Breniac <Breniac hardware>` is the VSC's Tier-1 cluster.
+
+.. include:: tier1_hardware/breniac_login_nodes.rst
+
+
+Running jobs
+------------
+
+The way you submit jobs on Breniac is similar to what you are used to on VSC Tier-2
+infrastructure, you can review the :ref:`documentation for a refresher <submitting jobs>`
+if necessary.
+
+.. warning::
+
+   On Breniac an accounting system is used, so you need to specify a project using
+   ``qsub``'s ``-A`` option.  If you are not familiar with a credit system,
+   please read the :ref:`documentation on credit system <credit system basics>`.
+
+.. note::
+
+   Since we use a routing queue on Breniac, you are advised not to explicitly
+   specify a queue using the ``-q`` option, but rather to simply specify the
+   required walltime (at most 3 days).
+
+There are several types of nodes in the Breniac cluster: compute nodes with skylake
+CPUs, and nodes with broadwell CPUs.  The latter have either 128 or 256 GB RAM.  See
+the documentation on :ref:`Breniac hardware <Breaniac hardware>` for details.
+
+
+.. _submit to Breniac skylake node:
+
+Submit to a skylake node
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To submit to a skylake compute node it all boils down to specifying the required
+number of nodes and cores, and desired feature. As the nodes have a single job
+policy we recommend to always request all available cores per node (28 cores in
+this case). For example to request 2 nodes with each 28 cores you can submit
+like this::
+
+   $ qsub -l nodes=2:ppn=28:skylake  -l walltime=2:00:00  -A myproject  myjobscript.pbs
+
+
+.. _submit to Breniac broadwell node:
+
+Submit to a broadwell node
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To submit to a broadwell compute node in case you don't care whether the job ends
+up on nodes with 128 or 256 GB RAM, you specify the required number of nodes and
+cores, and desired feature. As the nodes have a single job policy we recommend to
+always request all available cores per node (28 cores in this case). For example
+to request 2 nodes with each 28 cores you can submit
+like this::
+
+   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  -A myproject  myjobscript.pbs
+
+If you want to make sure your job will run on nodes with 128 GB RAM, you
+add a feature specification::
+
+   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  -l feature=mem128 \
+          -A myproject  myjobscript.pbs
+
+
+.. _submit to Breniac 256 GB broadwell node:
+
+Submit to a 256 GB broadwell node
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To submit to a broadwell compute node that has 256 GB RAM, you specify the required
+number of nodes and cores, and desired feature. As the nodes have a single job policy
+we recommend to always request all available cores per node (28 cores in this case).
+For example to request 2 nodes with each 28 cores you can submit like this::
+
+   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  -l feature=mem256 \
+          -A myproject  myjobscript.pbs
+
+
+Debug jobs on Breniac
+---------------------
+
+Debugging an application on a busy cluster can sometimes pose a problem due to
+long queuing times.  For this purpose, 4 nodes have been reserved as debugging
+nodes.  A few restrictions apply:
+
+- you can only submit a single debug job at the time,
+- the debug job can use at most 4 nodes, and
+- the maximum walltime for a debug job is 1 hour.
+
+To submit a job to run on the debug nodes, you have to specify the partition::
+
+   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  l qos=debugging \
+          -A myproject  myjobscript.pbs

--- a/source/leuven/breniac_quickstart.rst
+++ b/source/leuven/breniac_quickstart.rst
@@ -6,6 +6,42 @@ Breniac quick start
 .. include:: tier1_hardware/breniac_login_nodes.rst
 
 
+Building/using software
+-----------------------
+
+Since Breniac has two types of architectures, some care needs to be taken
+when building software, or selecting software to run.  The newer skylake
+CPUs support the AVX-512 instruction set, which improves vectoriazation
+oncsiderably.  Both skylake and broadwell nodes support AVX2.
+
+Computationally intensive software is best compiled with archtecture-specific
+optimizations.  The software stack typically has versions optimized for the
+two architectures, and the appropriate packages for an architecture are
+the default on nodes with that architecture.
+
+If you want to, e.g., check the availability of software for a different
+architecture from the node you are currenly on, you can do that by adding
+the appropriate module path, i.e.,
+
+- for broadwell::
+
+     $ module use /apps/leuven/broadwell/2018a/modules/all
+
+- for skylake::
+
+     $ module use /apps/leuven/skylake/2018a/modules/all
+
+The compile options to use for a specific architecture, or to build a fat
+binary (Intel only) are listed in the documentation on the :ref:`foss
+toolchain <FOSS toolchain>` and the :ref:`Intel toolchain <Intel toolchain>`.
+
+.. note::
+
+   Please run a (:ref:`interactive <interactive jobs>`) job to do builds on nodes
+   with the target architectures.  This is best practice in any case since software
+   builds tax the shared login nodes, and may disrupt the work of other users.
+
+
 Running jobs
 ------------
 
@@ -83,8 +119,8 @@ Debug jobs on Breniac
 ---------------------
 
 Debugging an application on a busy cluster can sometimes pose a problem due to
-long queuing times.  For this purpose, 4 nodes have been reserved as debugging
-nodes.  A few restrictions apply:
+long queuing times.  For this purpose, 4 broadwell nodes have been reserved as
+debugging nodes.  A few restrictions apply:
 
 - you can only submit a single debug job at the time,
 - the debug job can use at most 4 nodes, and
@@ -94,3 +130,4 @@ To submit a job to run on the debug nodes, you have to specify the partition::
 
    $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  l qos=debugging \
           -A myproject  myjobscript.pbs
+

--- a/source/leuven/breniac_quickstart.rst
+++ b/source/leuven/breniac_quickstart.rst
@@ -1,5 +1,5 @@
-Breniac quick start
-===================
+Breniac quick start guide
+=========================
 
 :ref:`Breniac <Breniac hardware>` is the VSC's Tier-1 cluster.
 
@@ -11,16 +11,16 @@ Building/using software
 
 Since Breniac has two types of architectures, some care needs to be taken
 when building software, or selecting software to run.  The newer skylake
-CPUs support the AVX-512 instruction set, which improves vectoriazation
-oncsiderably.  Both skylake and broadwell nodes support AVX2.
+CPUs support the AVX-512 instruction set, which improves vectorization
+considerably.  Both skylake and broadwell nodes support AVX2.
 
-Computationally intensive software is best compiled with archtecture-specific
+Computationally intensive software is best compiled with architecture-specific
 optimizations.  The software stack typically has versions optimized for the
 two architectures, and the appropriate packages for an architecture are
 the default on nodes with that architecture.
 
 If you want to, e.g., check the availability of software for a different
-architecture from the node you are currenly on, you can do that by adding
+architecture from the node you are currently on, you can do that by adding
 the appropriate module path, i.e.,
 
 - for broadwell::
@@ -37,23 +37,27 @@ toolchain <FOSS toolchain>` and the :ref:`Intel toolchain <Intel toolchain>`.
 
 .. note::
 
-   Please run a (:ref:`interactive <interactive jobs>`) job to do builds on nodes
-   with the target architectures.  This is best practice in any case since software
-   builds tax the shared login nodes, and may disrupt the work of other users.
+   Please run a (:ref:`interactive <interactive jobs>`) job to do builds
+   on nodes with the target architectures.  This is best practice in any
+   case since software builds tax the shared login nodes, and may disrupt
+   the work of other users.
 
 
 Running jobs
 ------------
 
-The way you submit jobs on Breniac is similar to what you are used to on VSC Tier-2
-infrastructure, you can review the :ref:`documentation for a refresher <submitting jobs>`
-if necessary.
+The way you submit jobs on Breniac is similar to what you are used to
+on VSC Tier-2 infrastructure, you can review the :ref:`documentation
+for a refresher <submitting jobs>` if necessary.
 
 .. warning::
 
-   On Breniac an accounting system is used, so you need to specify a project using
-   ``qsub``'s ``-A`` option.  If you are not familiar with a credit system,
-   please read the :ref:`documentation on credit system <credit system basics>`.
+   On Breniac an accounting system is used, so you need to specify a
+   project using ``qsub``'s ``-A`` option.  If you are not familiar with
+   a credit system, please read the :ref:`documentation on credit system
+   <credit system basics>`.
+
+The charge rate is the same for all nodes, i.e., 1 credit per node-day.
 
 .. note::
 
@@ -61,9 +65,10 @@ if necessary.
    specify a queue using the ``-q`` option, but rather to simply specify the
    required walltime (at most 3 days).
 
-There are several types of nodes in the Breniac cluster: compute nodes with skylake
-CPUs, and nodes with broadwell CPUs.  The latter have either 128 or 256 GB RAM.  See
-the documentation on :ref:`Breniac hardware <Breaniac hardware>` for details.
+There are several types of nodes in the Breniac cluster: compute nodes
+with skylake CPUs, and nodes with broadwell CPUs.  The latter have either
+128 or 256 GB RAM.  See the documentation on :ref:`Breniac hardware
+<Breaniac hardware>` for details.
 
 
 .. _submit to Breniac skylake node:
@@ -71,13 +76,14 @@ the documentation on :ref:`Breniac hardware <Breaniac hardware>` for details.
 Submit to a skylake node
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-To submit to a skylake compute node it all boils down to specifying the required
-number of nodes and cores, and desired feature. As the nodes have a single job
-policy we recommend to always request all available cores per node (28 cores in
-this case). For example to request 2 nodes with each 28 cores you can submit
-like this::
+To submit to a skylake compute node it all boils down to specifying the
+required number of nodes and cores, and desired feature. As the nodes have
+a single job policy we recommend to always request all available cores per
+node (28 cores in this case). For example to request 2 nodes with each 28
+cores you can submit like this::
 
-   $ qsub -l nodes=2:ppn=28:skylake  -l walltime=2:00:00  -A myproject  myjobscript.pbs
+   $ qsub -l nodes=2:ppn=28:skylake  -l walltime=2:00:00  \
+          -A myproject  myjobscript.pbs
 
 
 .. _submit to Breniac broadwell node:
@@ -85,19 +91,20 @@ like this::
 Submit to a broadwell node
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To submit to a broadwell compute node in case you don't care whether the job ends
-up on nodes with 128 or 256 GB RAM, you specify the required number of nodes and
-cores, and desired feature. As the nodes have a single job policy we recommend to
-always request all available cores per node (28 cores in this case). For example
-to request 2 nodes with each 28 cores you can submit
-like this::
+To submit to a broadwell compute node in case you don't care whether the
+job ends up on nodes with 128 or 256 GB RAM, you specify the required
+number of nodes and cores, and desired feature. As the nodes have a single
+job policy we recommend to always request all available cores per node (28
+cores in this case). For example to request 2 nodes with each 28 cores you
+can submit like this::
 
-   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  -A myproject  myjobscript.pbs
+   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  \
+          -A myproject  myjobscript.pbs
 
 If you want to make sure your job will run on nodes with 128 GB RAM, you
 add a feature specification::
 
-   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  -l feature=mem128 \
+   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  -l feature=mem128  \
           -A myproject  myjobscript.pbs
 
 
@@ -106,10 +113,11 @@ add a feature specification::
 Submit to a 256 GB broadwell node
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To submit to a broadwell compute node that has 256 GB RAM, you specify the required
-number of nodes and cores, and desired feature. As the nodes have a single job policy
-we recommend to always request all available cores per node (28 cores in this case).
-For example to request 2 nodes with each 28 cores you can submit like this::
+To submit to a broadwell compute node that has 256 GB RAM, you specify the
+required number of nodes and cores, and desired feature. As the nodes have
+a single job policy we recommend to always request all available cores per
+node (28 cores in this case).  For example to request 2 nodes with each 28
+cores you can submit like this::
 
    $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  -l feature=mem256 \
           -A myproject  myjobscript.pbs
@@ -126,8 +134,95 @@ debugging nodes.  A few restrictions apply:
 - the debug job can use at most 4 nodes, and
 - the maximum walltime for a debug job is 1 hour.
 
-To submit a job to run on the debug nodes, you have to specify the partition::
+To submit a job to run on the debug nodes, you have to specify the Quality
+Of Service (``qos``)::
 
-   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  l qos=debugging \
+   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  -l qos=debugging \
           -A myproject  myjobscript.pbs
 
+
+
+Job communication and network islands
+-------------------------------------
+
+Breniac's interconnect is partitioned into islands. The communication
+latency will be minimal for nodes that are part of the same island.
+
+Hence if your job runs on less than 24 nodes (or 672 cores) you can
+request that all nodes the job runs on are in the same island.  This
+is done by specifying the ``singleisland`` feature::
+
+   $ qsub -l nodes=20:ppn=28  -l walltime=2:00:00  -l feature=singleisland \
+          -A myproject  myjobscript.pbs
+
+
+Running on specific nodes/islands
+---------------------------------
+
+You can request that your job runs on specific nodes, islands or racks,
+for, e.g., benchmarking purposes.
+
+.. note::
+
+   On a busy cluster this means that the queue time of your jobs may
+   increase substantially, so only request specific nodes, islands or
+   racks when you really need to.
+
+Running jobs on specific nodes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To run a job on node ``r13i03n1``, you would request::
+
+   $ qsub -l nodes=r13i03n1:ppn=28  -l walltime=2:00:00  \
+          -A myproject  myjobscript.pbs
+
+To submit a job on multiple nodes, e.g., ``r13i03n1`` and ``r13i03n2``,
+use the following syntax::
+
+   $ qsub -l nodes=r13i03n1:ppn=28+r13i03n2:ppn=28  -l walltime=2:00:00  \
+          -A myproject  myjobscript.pbs
+
+
+Running jobs on specific islands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The islands are indicated on the visual representation of the
+cluster in the :ref:`hardware documentation <Breniac hardware>`.  The
+names of islands follow the pattern ``r<xx>i<yy>``, where ``<xx>`` is
+the number of the rack, and ``<yy>`` depends on the rack.
+
+- For ``<xx>`` is ``01`` to ``04``: ``<yy>`` is ``01``, ``11`` or ``23``.
+- For ``<xx>`` is ``05``: ``<yy>`` is ``01`` or ``11``.
+- For ``<xx>`` is ``06`` to ``09``: ``<yy>`` is ``01``, ``11`` or ``23``.
+- For ``<xx>`` is ``11`` to ``r14``: ``<yy>`` is ``03`` or ``15``.
+- For ``<xx>`` is ``15``: ``<yy>`` is ``03``.
+- For ``<xx>`` is ``16`` to ``r19``: ``<yy>`` is ``03`` or ``15``.
+
+To, e.g., run on island ``r16i15`` specify the resource request as::
+
+   $ qsub -l nodes=10:ppn=28  -l walltime=2:00:00  -l feature=r16i15  \
+          -A myproject  myjobscript.pbs
+
+.. note::
+
+   Not all islands have the same number of nodes, e.g., ``r01i01`` has
+   20 nodes, while ``r01i11`` has 24.  Consult the :ref:`visual
+   representation  of the cluster <Breniac hardware>` for an overview.
+
+
+Running jobs on specific racks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For larger jobs that still fit within a single rack, you can specify
+that rack as ``r<xx>`` where ``<xx>`` is ``01`` to ``09``, or ``11`` to
+``19``.  For example, to request 40 nodes in ``r02``, you would
+request::
+
+   $ qsub -l nodes=40:ppn=28  -l walltime=2:00:00  -l feature=r02  \
+          -A myproject  myjobscript.pbs
+
+.. note::
+
+   Not all racks have the same number of nodes, e.g., ``r01`` has
+   68 nodes, while ``r12`` has 48.  Consult the :ref:`visual
+   representation  of the cluster <Breniac hardware>` for an overview.

--- a/source/leuven/credits.rst
+++ b/source/leuven/credits.rst
@@ -1,0 +1,110 @@
+Credits to use KU Leuven infrastructure
+=======================================
+
+KU Leuven uses a credit system to do accounting on the HPC systems it hosts.
+This is the case for its Tier-2 clusters, as well as the Tier-1 infrastructure.
+
+
+How do I request credits on the KU Leuven Tier-2 systems
+--------------------------------------------------------
+
+KU Leuven users
+~~~~~~~~~~~~~~~
+You can request two types of job credits: introduction credits and project
+credits.
+
+Introduction credits
+   This is a limited amount of free credits for test and development purposes.
+Project credits
+   These are job credits used for actual research and production runs.
+
+You will find the relevant information to apply for both types of credits,
+including pricing, in the `Service Catalog`_ (login required).
+
+UHasselt users
+~~~~~~~~~~~~~~
+If you would like credits for a new project, please fill out the
+`credit request form`_.  Please read and follow the instructions in that
+form carefully.
+
+If you require additional credits for an existing project, please contact
+your VSC coordinator `Geert Jan Bex`_.
+
+Other users
+~~~~~~~~~~~
+
+Please contact your VSC coordinator/contact or your :ref:`local support staff
+<Contact VSC>`.
+
+Job cost calculation
+~~~~~~~~~~~~~~~~~~~~
+
+The cost of a job depends on the resources it consumes. Generally
+speaking, one credit buys the user one hour of walltime on one reference
+node. The resources that are taken into account to charge for a job are
+the walltime it consumed, and the number and type of compute nodes it
+ran on. The following formula is used:
+
+0.000278 \* *nodes* \* *walltime* \* *nodetype*
+
+Where
+
+-  *nodes* is the number of compute nodes the job ran on;
+-  *walltime* the effective duration of the job, expressed in seconds;
+-  *nodetype* is the factor representing the node type's performance as
+   listed in the table below.
+
+Since Tier-2 cluster has several types of compute nodes, none of which
+is actually a reference node, the following values for *nodetype* apply:
+
++----------------+--------------+
+| node type      | credit/hour  |
++================+==============+
+| ivybridge      | 4.76         |
++----------------+--------------+
+| haswell        | 6.68         |
++----------------+--------------+
+| skylake        | 10.00        |
++----------------+--------------+
+| skylake bigmem | 12.00        |
++----------------+--------------+
+| GPU            | 5.00 per GPU |
++----------------+--------------+
+
+The difference in cost between different machines/processors reflects
+the performance difference between those types of nodes. The total cost
+of a job will typically be the same on any compute nodes, but the
+walltime will be different nodes.
+
+An example of a job running on multiple nodes and cores is given below::
+
+   $ qsub  -A lp_astrophysics_014  -l nodes=2:ppn=20:ivybridge  simulation_3415.pbs
+
+If this job finished in 2.5 hours (i.e., walltime is 9000), the user
+will be charged:
+
+0.000278 \* 2 \* 9000 \* 4.76 = 23.8 credits
+
+For a single node, single core job that also took 2.5 hours and was
+submitted as::
+
+   $ qsub  -A lp_astrophysics_014  -l nodes=1:ppn=1:ivybridge  simulation_147.pbs
+
+In this case, the user will be charged:
+
+0.000278 \* 1 \* 9000 \* 4.76 = 11.9 credits
+
+
+How do I get credits to use the Tier-1 infrastructure
+-----------------------------------------------------
+
+Access to the Tier-1 is project-based, if you have a starting grant or
+an approved project, or you pay for your compute time, you should have
+received information on your job credits.  If not, please :ref:`contact
+support <Contact VSC>`.
+
+
+
+.. _Geert Jan Bex: mailto:geertjan.bex@uhasselt.be
+.. _credit request form:  https://admin.kuleuven.be/icts/onderzoek/hpc/request-project-credits
+.. include:: jobs/links.rst

--- a/source/leuven/credits.rst
+++ b/source/leuven/credits.rst
@@ -1,8 +1,13 @@
+.. _KU Leuven credits:
+
 Credits to use KU Leuven infrastructure
 =======================================
 
 KU Leuven uses a credit system to do accounting on the HPC systems it hosts.
 This is the case for its Tier-2 clusters, as well as the Tier-1 infrastructure.
+
+Information on how to use the credit system can be found in the :ref:`documentation
+on credit system basics <credit system basics>`.
 
 
 How do I request credits on the KU Leuven Tier-2 systems
@@ -24,8 +29,11 @@ including pricing, in the `Service Catalog`_ (login required).
 UHasselt users
 ~~~~~~~~~~~~~~
 If you would like credits for a new project, please fill out the
-`credit request form`_.  Please read and follow the instructions in that
-form carefully.
+`credit request form`_.
+
+.. warning::
+
+   Please read and follow the instructions in that form carefully!
 
 If you require additional credits for an existing project, please contact
 your VSC coordinator `Geert Jan Bex`_.
@@ -35,6 +43,7 @@ Other users
 
 Please contact your VSC coordinator/contact or your :ref:`local support staff
 <Contact VSC>`.
+
 
 Job cost calculation
 ~~~~~~~~~~~~~~~~~~~~
@@ -55,32 +64,25 @@ Where
    listed in the table below.
 
 Since Tier-2 cluster has several types of compute nodes, none of which
-is actually a reference node, the following values for *nodetype* apply:
+is actually a reference node, the values can be found in the specific
+documentation for each of the systems:
 
-+----------------+--------------+
-| node type      | credit/hour  |
-+================+==============+
-| ivybridge      | 4.76         |
-+----------------+--------------+
-| haswell        | 6.68         |
-+----------------+--------------+
-| skylake        | 10.00        |
-+----------------+--------------+
-| skylake bigmem | 12.00        |
-+----------------+--------------+
-| GPU            | 5.00 per GPU |
-+----------------+--------------+
+- :ref:`Thinking <running jobs on thinking>`
+- :ref:`Genius <running jobs on genius>`
 
 The difference in cost between different machines/processors reflects
 the performance difference between those types of nodes. The total cost
 of a job will typically be the same on any compute nodes, but the
-walltime will be different nodes.
+walltime will be different, depending on the performance of the nodes.
+
+In the examples below, you run your jobs on an ``ivybridge`` node, for which
+we charge 4.76 credits per hour.
 
 An example of a job running on multiple nodes and cores is given below::
 
    $ qsub  -A lp_astrophysics_014  -l nodes=2:ppn=20:ivybridge  simulation_3415.pbs
 
-If this job finished in 2.5 hours (i.e., walltime is 9000), the user
+If this job finished in 2.5 hours (i.e., walltime is 9000 seconds), the user
 will be charged:
 
 0.000278 \* 2 \* 9000 \* 4.76 = 23.8 credits
@@ -102,7 +104,6 @@ Access to the Tier-1 is project-based, if you have a starting grant or
 an approved project, or you pay for your compute time, you should have
 received information on your job credits.  If not, please :ref:`contact
 support <Contact VSC>`.
-
 
 
 .. _Geert Jan Bex: mailto:geertjan.bex@uhasselt.be

--- a/source/leuven/genius_quick_start.rst
+++ b/source/leuven/genius_quick_start.rst
@@ -69,14 +69,14 @@ The big memory nodes are also located in a separate partition. In case of the bi
 
 Submit to an AMD node
 ~~~~~~~~~~~~~~~~~~~~~
-The AMD nodes are in their own parition.  Besides specifying the partition,
+The AMD nodes are in their own partition.  Besides specifying the partition,
 it is also important to specify the memory per process (``pmem``) since
 the AMD nodes have 256 GB of RAM, which implies that the default value is
 too high, and your job will never run.
 
 For example::
 
-   $ qsub -l nodes=2:ppn=64  -l pmem=3800mb  -l parition=amd  -A myproject  myscript.pbs
+   $ qsub -l nodes=2:ppn=64  -l pmem=3800mb  -l partition=amd  -A myproject  myscript.pbs
 
 This resource specification for the memory is a few GB less than 256 GB,
 leaving some room for the operating system to function properly.

--- a/source/leuven/genius_quick_start.rst
+++ b/source/leuven/genius_quick_start.rst
@@ -10,9 +10,27 @@ For example, to log in to any of the login node using SSH::
    $ ssh vscXXXXX@login.hpc.kuleuven.be
 
 
+.. _running jobs on genius:
+
 Running jobs
 ------------
-There are several type of nodes in the Genius cluster: normal compute nodes, GPU nodes, big memory nodes.
+There are several type of nodes in the Genius cluster: normal compute nodes,
+GPU nodes, big memory nodes.  For information on systems, see the :ref:`hardware
+specification <Genius hardware>`.
+
+The charge rate for the various node types of Genius are listed in the table
+below.  Information on :ref:`obtaining credits <KU Leuven credits>` and
+:ref:`credit system basics <credit system basics>` is available.
+
++----------------+--------------+
+| node type      | credit/hour  |
++================+==============+
+| skylake        | 10.00        |
++----------------+--------------+
+| skylake bigmem | 12.00        |
++----------------+--------------+
+| GPU            | 5.00 per GPU |
++----------------+--------------+
 
 
 .. _submit to genius compute node:

--- a/source/leuven/thinking7_quickstart.rst
+++ b/source/leuven/thinking7_quickstart.rst
@@ -1,50 +1,75 @@
 ThinKing7 quick start guide
 ===========================
 
-:ref:`ThinKing7 <thinking7 hardware>` is the old ThinKing cluster that got an upgrade to CentOS 7.6. The cluster is at the end of its lifetime. The Ivybridge nodes will be removed by the end of 2019. The Hasswell nodes have a little longer to go. ThinKing can be used for most workloads, but have a look at :ref:`Genius <Genius hardware>` for the most recent hardware.
+:ref:`ThinKing7 <thinking7 hardware>` is the old ThinKing cluster that got an upgrade to CentOS 7.6. The cluster is at the end of its lifetime. The ivybridge nodes will be removed by the end of 2019. The haswell nodes have a little longer to go. ThinKing can be used for most workloads, but have a look at :ref:`Genius <Genius hardware>` for the most recent hardware.
 
 How to connect to ThinKing?
 ---------------------------
 
-All users having an active VSC account can connect to the login node(s).You can login through 1 general login node which will loadbalance your connection to one of the available login nodes using the command::
+All users having an active VSC account can connect to the login node(s).You can login through 1 general login node which will load balance your connection to one of the available login nodes using the command::
 
    $ ssh vscXXXXX@login-thinking.hpc.kuleuven.be
 
-ThinKing has 4 dedicated login nodes. You can directly login to these nodes with the same credentials, by using their hostname
+ThinKing has 4 dedicated login nodes. You can directly login to these nodes with the same credentials, by using their host name
 
 Normal login nodes:
 
 - ``login5-tier2.hpc.kuleuven.be``
 - ``login6-tier2.hpc.kuleuven.be``
 
-With a visualization capabilities (2 nvidia Quadro K5200 GPUs):
+With a visualization capabilities (2 NVIDIA Quadro K5200 GPUs):
 
 - ``login7-tier2.hpc.kuleuven.be``
 - ``login8-tier2.hpc.kuleuven.be``
     
-For visualization nodes please refer to the :ref:`TurboVNC documentation <TurboVNC start guide>`.
+For information on how to use the visualization capabilities of these
+login nodes, please refer to the :ref:`TurboVNC documentation
+<TurboVNC start guide>`.
+
+
+.. _running jobs on thinking:
 
 Running jobs
 ------------
 
-Remind that with migration to CentOS 7.6 toolchain starting from 2018a are available for Ivybride nodes and Haswell nodes. Older toolchains are no longer available. By default toolchain 2018a is loaded, for the CPU type of the specific node. If you want to load the toolchains explicitly you find then at
+Remember that since the migration to CentOS 7.6, toolchain starting from 2018a
+are available for ivybridge and haswell nodes. Older toolchains are no longer
+available. By default toolchain 2018a is loaded, for the CPU type of the
+specific node. If you want to load the toolchains explicitly you find them at
 
 - for ivybridge::
 
-     module use /apps/leuven/ivybridge/2018a/modules/all
+     $ module use /apps/leuven/ivybridge/2018a/modules/all
 
 - for haswell::
  
-     module use /apps/leuven/haswell/2018a/modules/all
+     $ module use /apps/leuven/haswell/2018a/modules/all
  
 ThinKing is now also using Lmod as module system. Have a look at  :ref:`Software stack <Software stack>` for more information.
 
-There are several type of nodes in the ThinKing cluster: compute nodes with ivybridge or haswell processors and some gpu nodes. Have a look at the hardware pages for more information.
+There are several type of nodes in the ThinKing cluster: compute nodes with ivybridge
+CPUs, haswell CPUs, and some GPU nodes with two NVIDIA K40c GPUs. Have a look at
+the :ref:`hardware pages <Thinking hardware>` for more information.
+
+The charge rate for the various node types of Thinking are listed in the table
+below.  Information on :ref:`obtaining credits <KU Leuven credits>` and
+:ref:`credit system basics <credit system basics>` is available.
+
++----------------+--------------+
+| node type      | credit/hour  |
++================+==============+
+| ivybridge      | 4.76         |
++----------------+--------------+
+| haswell        | 6.68         |
++----------------+--------------+
+| K40c GPU nodes | 2.86         |
++----------------+--------------+
+
 
 Submit to a compute node
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-To submit to a compute node it all boils down to specifying the required number of nodes and cores. As the nodes have a single user policy we recommend to always request all available cores por node (20 in case of ivybridge nodes and 24 in case of haswell nodes). For example to request 2 nodes with each 24 cores for 1 hour you can submit like this::
+To submit to a compute node it all boils down to specifying the required number of nodes and cores. As the nodes have a single user policy we recommend to always request all available cores per node (20 in case of ivybridge nodes and 24 in case of haswell nodes). For example to request 2 nodes with each 24 cores for 1 hour you can submit like this::
 
    $ qsub -l nodes=2:ppn=24  -l walltime=1:00:00  -A myproject  myjob.pbs
 

--- a/source/leuven/thinking7_quickstart.rst
+++ b/source/leuven/thinking7_quickstart.rst
@@ -84,12 +84,9 @@ You always need to submit with a project account (-A). To find out which project
 Submit to a GPU node
 ~~~~~~~~~~~~~~~~~~~~
 
-The GPU nodes are located in a separate cluster partition so you will need to explicitly specify it when submitting your job. On ThinKing the GPU nodes are not a shared resources, so you are the only user of the node. However you need to request the number of GPU's you want to use. 
-
-For the K20::
-
-   $ qsub -A myproject  -l walltime=1:00:00  -l nodes=1:ppn=12:gpus=2:K20Xm  -l partition=gpu  myjob.pbs
-
-For the K40::
+The GPU nodes are located in a separate cluster partition so you will need to
+explicitly specify it when submitting your job. On ThinKing the GPU nodes are
+not a shared resources, so you are the only user of the node. However you need
+to request the number of GPUs you want to use:: 
 
    $ qsub -A myproject -l walltime=1:00:00  -l nodes=1:ppn=20:gpus=2:K40c  -l partition=gpu  myjob.pbs

--- a/source/leuven/tier1_hardware/breniac_hardware.rst
+++ b/source/leuven/tier1_hardware/breniac_hardware.rst
@@ -18,14 +18,14 @@ Hardware details
 
 - 436 broadwell nodes
 
-   - 2 Xeon E5-2680v4 CPUs@2.4GHz, 14 cores each
+   - 2 Xeon E5-2680v4 CPUs\@2.4GHz, 14 cores each
    - 128 GB RAM
    - 75 GB SSD local disk
    - specific ``qsub`` :ref:`options <submit to Breniac broadwell node>` apply
 
 - 144 broadwell nodes
 
-   - 2 Xeon E5-2680v4 CPUs@2.4GHz, 14 cores each
+   - 2 Xeon E5-2680v4 CPUs\@2.4GHz, 14 cores each
    - 256 GB RAM
    - 75 GB SSD local disk
    - specific ``qsub`` :ref:`options <submit to Breniac 256 GB broadwell node>` apply

--- a/source/leuven/tier1_hardware/breniac_hardware.rst
+++ b/source/leuven/tier1_hardware/breniac_hardware.rst
@@ -11,21 +11,24 @@ Hardware details
 
 - 408 skylake nodes
 
-    - 2 Xeon Gold 6132 CPU\@2.6GHz, 14 cores each
-    - 192 GB RAM
-    - 75 GB SSD local disk
+   - 2 Xeon Gold 6132 CPU\@2.6GHz, 14 cores each
+   - 192 GB RAM
+   - 75 GB SSD local disk
+   - specific ``qsub`` :ref:`options <submit to Breniac skylake node>` apply
 
 - 436 broadwell nodes
 
    - 2 Xeon E5-2680v4 CPUs@2.4GHz, 14 cores each
    - 128 GB RAM
    - 75 GB SSD local disk
+   - specific ``qsub`` :ref:`options <submit to Breniac broadwell node>` apply
 
 - 144 broadwell nodes
 
    - 2 Xeon E5-2680v4 CPUs@2.4GHz, 14 cores each
    - 256 GB RAM
    - 75 GB SSD local disk
+   - specific ``qsub`` :ref:`options <submit to Breniac 256 GB broadwell node>` apply
 
 The nodes are connected using an Infiniband EDR network.
 

--- a/source/leuven/tier1_hardware/breniac_login_nodes.rst
+++ b/source/leuven/tier1_hardware/breniac_login_nodes.rst
@@ -13,14 +13,18 @@ Two types of login nodes are available:
 - a classic login node, i.e., SSH access.
 
   - ``login1-tier1.hpc.kuleuven.be``
-
-- a login nodes with GPUs for visualization, and :ref:`NX clients
-  <NX start guide>`.
-
-  .. note::
-
-     The node listed below can only directly be accessed using SSH,
-     use ``nx-tier1.hpc.kuleuven.be`` as hostname in the NX client
-     configuraton.
-
   - ``login2-tier1.hpc.kuleuven.be``
+
+- a login node that provides a desktop environment that can be used for,
+  e.g., visualization, see the :ref:`NX clients section <NX start guide>`:
+
+  - ``nx-tier1.hpc.kuleuven.be``
+
+.. warning::
+
+   This node *should not* be accessed using terminal SSH, it serves only
+   as a gateway to the actual login nodes your NX sessions will be running
+   on.
+
+The NX login node will start a session on a login node that has a GPU, i.e.,
+``login2-tier1.hpc.kuleuven.be``.


### PR DESCRIPTION
A link to a somewhat outdated PDF was sent to new users of Breniac.  The information therein has now been added to the documentation site, updated and streamlined.