### PR TITLE
Minor corrections

### DIFF
--- a/source/jobs/worker_framework.rst
+++ b/source/jobs/worker_framework.rst
@@ -1,7 +1,7 @@
 .. _worker framework:
 
-worker quickstart
-=================
+worker quick start
+==================
 
 Purpose
 -------

--- a/source/jobs/worker_or_atools.rst
+++ b/source/jobs/worker_or_atools.rst
@@ -11,7 +11,7 @@ very common scenario, so we developed software to do that for you.
 Two general purpose software packages are available:
 
 - the `worker framework <https://github.com/gjbex/worker>`_ (:ref:`worker
-  quickstart <worker framework>` and `worker documentation`_) and
+  quick start <worker framework>` and `worker documentation`_) and
 - `atools <https://github.com/gjbex/atools>`_ (`atools documentation`_).
 
 Both are designed to handle this use case, but each has its own strengths

--- a/source/leuven/running_jupyter_notebooks.rst
+++ b/source/leuven/running_jupyter_notebooks.rst
@@ -18,10 +18,11 @@ Prerequisites
 
 The most convenient way to install Jupyter, and any other Python packages
 you require is using conda.  In case you're not familiar with conda, please
-check out the [quickstart guide](INSTALL_CONDA.md).  In this how-to, we will
-assume that the conda environment's name that has Jupyter installed is
-`science`.  We will also assume that the `$VSC_DATA/miniconda3/bin`
-directory is in your ``PATH`` variable.
+check out the information on :ref:`managing Python packages using conda
+<conda for Python>`.  In this how-to, we will assume that the conda
+environment's name that has Jupyter installed is `science`.  We will also
+assume that the `$VSC_DATA/miniconda3/bin` directory is in your ``PATH``
+variable.
 
 
 Using a notebook on an NX node

--- a/source/leuven/tier2_hardware/superdome_hardware.rst
+++ b/source/leuven/tier2_hardware/superdome_hardware.rst
@@ -16,4 +16,4 @@ Hardware details
     
 So in total Superdome has 6TB RAM memory and additionally a local shared scratch file system of 6TB.
 
-A :ref:`quickstart guide <Superdome quick start guide>` is available to get you started on submitting jobs to the Superdome.
+A :ref:`quick start guide <Superdome quick start guide>` is available to get you started on submitting jobs to the Superdome.

--- a/source/leuven/tier2_hardware/thinking_centos7_hardware.rst
+++ b/source/leuven/tier2_hardware/thinking_centos7_hardware.rst
@@ -57,7 +57,8 @@ Hardware details
 
 In the older partition of the cluster, nodes are connected via a QDR infiniband interconnect, while the newer partition has a faster FDR interconnect.  See the diagram below.
 
-A :ref:`quickstart guide <Thinking7 quick start guide>` is available to get you started on submitting jobs to the updated ThinKing cluster.
+A :ref:`quick start guide <Thinking7 quick start guide>` is available to get you
+started on submitting jobs to the updated ThinKing cluster.
 
 |Thinking CentOS 7 hardware|
 

--- a/source/software/python_package_management.rst
+++ b/source/software/python_package_management.rst
@@ -43,6 +43,8 @@ separately. These packages will not be listed by ``pip`` unless you
 loaded the corresponding module.
 
 
+.. _conda for Python:
+
 Install your own packages using conda
 -------------------------------------
 


### PR DESCRIPTION
* Make spelling of 'quick start' consistent.
* Fix old markdown link to `conda` information.