### PR TITLE
Lower job walltime to comply with debug walltime limit

### DIFF
--- a/source/leuven/breniac_quickstart.rst
+++ b/source/leuven/breniac_quickstart.rst
@@ -139,7 +139,7 @@ debugging nodes.  A few restrictions apply:
 To submit a job to run on the debug nodes, you have to specify the Quality
 Of Service (``qos``)::
 
-   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=2:00:00  -l qos=debugging \
+   $ qsub -l nodes=2:ppn=28:broadwell  -l walltime=1:00:00  -l qos=debugging \
           -A myproject  myjobscript.pbs
 
 


### PR DESCRIPTION
An extremely tiny (but still relevant!) change, which seemed like a good occasion to start working on VscDocumentation.

So the thing is that the Breniac debug job example displayed a walltime of 2 hours, but the maximum debug queue walltime (as specified in the lines above it) is only 1 hour.