### PR TITLE
add html_title

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -28,6 +28,9 @@ version = ''
 # The full version, including alpha/beta/rc tags
 release = '1.0'
 
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+html_title = project
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
this reduces the lengthy text on the navigation bar from 'VSC documentation 1.0 documentation' to simply 'VSC documentation'