### PR TITLE
Add note about maximal number of user jobs in BrENIAC queue

### DIFF
--- a/source/leuven/breniac_quickstart.rst
+++ b/source/leuven/breniac_quickstart.rst
@@ -67,6 +67,19 @@ The charge rate is the same for all nodes, i.e., 1 credit per node-day.
    specify a queue using the ``-q`` option, but rather to simply specify the
    required walltime (at most 3 days).
 
+.. note::
+
+   There is a limit on the number of jobs you can have in a queue. This number
+   includes idle, running, and blocked jobs. If you try to submit more jobs
+   than the maximum number, these jobs will be deferred and will not start.
+   Therefore you should always respect the following limits on how many jobs
+   you have in a queue at the same time:
+
+   - q1h: max_user_queueable = 400
+   - q24h: max_user_queueable = 500
+   - q72h: max_user_queueable = 300
+   - q7d: max_user_queueable = 20
+
 There are several types of nodes in the Breniac cluster: compute nodes
 with skylake CPUs, and nodes with broadwell CPUs.  The latter have either
 128 or 256 GB RAM.  See the documentation on :ref:`Breniac hardware

--- a/source/leuven/breniac_quickstart.rst
+++ b/source/leuven/breniac_quickstart.rst
@@ -78,7 +78,6 @@ The charge rate is the same for all nodes, i.e., 1 credit per node-day.
    - q1h: max_user_queueable = 400
    - q24h: max_user_queueable = 500
    - q72h: max_user_queueable = 300
-   - q7d: max_user_queueable = 20
 
 There are several types of nodes in the Breniac cluster: compute nodes
 with skylake CPUs, and nodes with broadwell CPUs.  The latter have either


### PR DESCRIPTION
Hopefully this note will restrain users from "oversubmitting" jobs.
I do not know who decided to put different limits for each queue, it makes things more complicated than they should be.