### PR TITLE
More info on singlejob policy

### DIFF
--- a/source/jobs/specifying_resources.rst
+++ b/source/jobs/specifying_resources.rst
@@ -124,7 +124,8 @@ use the following two options:
    run on the same nodes if not all cores are used.
 ``-l naccesspolicy=singlejob``
    This will make sure that no other job can use the nodes allocated
-   to your job.
+   to your job. When requesting half a node or less on Genius and ThinKing,
+   you will also need to add ``-l qos=shared`` to enforce this policy.
   
 .. warning::
 


### PR DESCRIPTION
Mentioning cases where `qos=shared` needs to be added in order to really get the `singlejob` node access policy (see also [Redmine ticket 76617](https://scm.icts.kuleuven.be/issues/76617)). As this is a minor change (adding one sentence), I will merge it right away.