### PR TITLE
add links to VNC documentation for VUB

### DIFF
--- a/source/access/linux_client.rst
+++ b/source/access/linux_client.rst
@@ -75,22 +75,23 @@ can sleep your laptop, disconnect and move to another network
 without loosing your X-session. Performance may also be better
 with many programs over high-latency networks.
 
-TurboVNC
-^^^^^^^^
+VNC
+^^^
+The KU Leuven/UHasselt, UAntwerp, and VUB clusters also offer support for
+visualization software through Virtual Network Computing (VNC). VNC renders
+images on the cluster and transfers the resulting images to your client device.
+VNC clients are available for Windows, macOS, Linux, Android and iOS.
 
-The KU Leuven/UHasselt and UAntwerp clusters also offer support
-for visualization software through TurboVNC. VNC renders images on
-the cluster and transfers the resulting images to your client
-device. VNC clients are available for Windows, macOS, Linux,
-Android and iOS.
-
--  On the KU Leuven/UHasselt clusters, :ref:`TurboVNC is supported on
-   the visualization nodes <TurboVNC start guide>`.
--  On the UAntwerp clusters, TurboVNC is supported on all regular
-   login nodes (without OpenGL support) and on the visualization
-   node of Leibniz (with OpenGL support through VirtualGL). See
-   the page ":ref:`Remote visualization @ UAntwerp <remote visualization
-   UAntwerp>`" for instructions.
+-  On the KU Leuven/UHasselt clusters, :ref:`TurboVNC<TurboVNC start guide>` is
+   supported on the visualization nodes.
+-  On the UAntwerp clusters, TurboVNC is supported on all regular login nodes
+   (without OpenGL support) and on the visualization node of Leibniz (with
+   OpenGL support through VirtualGL). See the page ":ref:`Remote visualization
+   UAntwerp`" for instructions.
+-  On the VUB clusters, TigerVNC is supported on all nodes. See our
+   documentation on `running graphical applications
+   <https://hpc.vub.be/docs/software/modules/#how-can-i-run-graphical-applications>`_
+   for instructions.
 
 
 Software development

--- a/source/access/macos_client.rst
+++ b/source/access/macos_client.rst
@@ -64,21 +64,22 @@ programs. Instead of an X-server, another piece of client software is
 required.
 
 
-TurboVNC
-^^^^^^^^
+VNC
+^^^
+The KU Leuven/UHasselt, UAntwerp, and VUB clusters also offer support for
+visualization software through Virtual Network Computing (VNC). VNC renders
+images on the cluster and transfers the resulting images to your client device.
+VNC clients are available for Windows, macOS, Linux, Android and iOS.
 
-The KU Leuven/UHasselt and UAntwerp clusters also offer support
-for visualization software through TurboVNC. VNC renders images on
-the cluster and transfers the resulting images to your client
-device. VNC clients are available for Windows, macOS, Linux,
-Android and iOS.
-
--  On the KU Leuven/UHasselt clusters, :ref:`TurboVNC is supported
-   on the visualization nodes <TurboVNC start guide>`.
--  On the UAntwerp clusters, TurboVNC is supported on all regular
-   login nodes (without OpenGL support) and on the visualization
-   node of Leibniz (with OpenGL support through VirtualGL). See
-   the page ":ref:`Remote visualization @ UAntwerp <remote visualization UAntwerp>`"
+-  On the KU Leuven/UHasselt clusters, :ref:`TurboVNC<TurboVNC start guide>` is
+   supported on the visualization nodes.
+-  On the UAntwerp clusters, TurboVNC is supported on all regular login nodes
+   (without OpenGL support) and on the visualization node of Leibniz (with
+   OpenGL support through VirtualGL). See the page ":ref:`Remote visualization
+   UAntwerp`" for instructions.
+-  On the VUB clusters, TigerVNC is supported on all nodes. See our
+   documentation on `running graphical applications
+   <https://hpc.vub.be/docs/software/modules/#how-can-i-run-graphical-applications>`_
    for instructions.
 
 

--- a/source/access/windows_client.rst
+++ b/source/access/windows_client.rst
@@ -64,19 +64,22 @@ On the KU Leuven/UHasselt clusters it is also possible to use the
 on to the machine and run graphical programs. Instead of an
 X server, another piece of client software is required.
 
-TurboVNC
-^^^^^^^^
-The KU Leuven/UHasselt and UAntwerp clusters also offer support
-for visualization software through TurboVNC. VNC renders images on
-the cluster and transfers the resulting images to your client
-device.
+VNC
+^^^
+The KU Leuven/UHasselt, UAntwerp, and VUB clusters also offer support for
+visualization software through Virtual Network Computing (VNC). VNC renders
+images on the cluster and transfers the resulting images to your client device.
+VNC clients are available for Windows, macOS, Linux, Android and iOS.
 
--  On the KU Leuven/UHasselt clusters, :ref:`TurboVNC<TurboVNC start guide>`
-   is supported on the visualization nodes.
--  On the UAntwerp clusters, TurboVNC is supported on all regular
-   login nodes (without OpenGL support) and on the visualization
-   node of Leibniz (with OpenGL support through VirtualGL). See
-   the page ":ref:`Remote visualization UAntwerp`"
+-  On the KU Leuven/UHasselt clusters, :ref:`TurboVNC<TurboVNC start guide>` is
+   supported on the visualization nodes.
+-  On the UAntwerp clusters, TurboVNC is supported on all regular login nodes
+   (without OpenGL support) and on the visualization node of Leibniz (with
+   OpenGL support through VirtualGL). See the page ":ref:`Remote visualization
+   UAntwerp`" for instructions.
+-  On the VUB clusters, TigerVNC is supported on all nodes. See our
+   documentation on `running graphical applications
+   <https://hpc.vub.be/docs/software/modules/#how-can-i-run-graphical-applications>`_
    for instructions.
 
 


### PR DESCRIPTION
@gjbex to avoid duplication, maybe we should put VNC (and NX client) in a separate page and link to that?