### PR TITLE
Explain how automatic file removal on scratch works

### DIFF
--- a/source/access/where_can_i_store_what_kind_of_data.rst
+++ b/source/access/where_can_i_store_what_kind_of_data.rst
@@ -35,6 +35,24 @@ on the size and usage of these data. Following locations are available:
    -  Several types exist, available in $VSC_SCRATCH_XXX variables
    -  For temporary or transient data; there is typically no backup for
       these filesystems, and 'old' data may be removed automatically.
+
+      .. note::
+
+          On the Tier-2 clusters in Leuven, the automatic file removal is
+          based on the moment a file was accessed for the last time. The
+          reasoning behind this is that as long as you are actively using a
+          file (so accessing it), the file will not be removed. This policy
+          can however cause confusion when files are initially transferred to
+          a scratch directory. If you use for instance the `mv` command, the
+          file is not actually accessed. When the last access timestamp of the
+          original file is a long time in the past, this file will be
+          considered to be inactive and automatically removed. A similar
+          thing happens when using `rsync` with the option to preserve
+          timestamps. Also `Midnight Commander` will always preserve
+          timestamps when copying or moving data. To avoid this problem, the
+          `cp` command (without `-a` argument) should be used for the
+          initial transfer of files to a scratch directory.
+
    -  Currently, $VSC_SCRATCH_NODE and $VSC_SCRATCH_SITE
       are defined for space that is available per
       node or per site on all nodes of the VSC.

--- a/source/access/where_can_i_store_what_kind_of_data.rst
+++ b/source/access/where_can_i_store_what_kind_of_data.rst
@@ -35,24 +35,6 @@ on the size and usage of these data. Following locations are available:
    -  Several types exist, available in $VSC_SCRATCH_XXX variables
    -  For temporary or transient data; there is typically no backup for
       these filesystems, and 'old' data may be removed automatically.
-
-      .. note::
-
-          On the Tier-2 clusters in Leuven, the automatic file removal is
-          based on the moment a file was accessed for the last time. The
-          reasoning behind this is that as long as you are actively using a
-          file (so accessing it), the file will not be removed. This policy
-          can however cause confusion when files are initially transferred to
-          a scratch directory. If you use for instance the `mv` command, the
-          file is not actually accessed. When the last access timestamp of the
-          original file is a long time in the past, this file will be
-          considered to be inactive and automatically removed. A similar
-          thing happens when using `rsync` with the option to preserve
-          timestamps. Also `Midnight Commander` will always preserve
-          timestamps when copying or moving data. To avoid this problem, the
-          `cp` command (without `-a` argument) should be used for the
-          initial transfer of files to a scratch directory.
-
    -  Currently, $VSC_SCRATCH_NODE and $VSC_SCRATCH_SITE
       are defined for space that is available per
       node or per site on all nodes of the VSC.

--- a/source/access/where_can_i_store_what_kind_of_data.rst
+++ b/source/access/where_can_i_store_what_kind_of_data.rst
@@ -62,6 +62,14 @@ open for the general quota warnings! The same holds for running jobs
 that need to write files: when you reach your hard quota, jobs will
 crash.
 
+A few additional site-specific remarks concerning data storage can be found
+on the following pages:
+
+   - :ref:`UAntwerpen<UAntwerpen storage>`
+   - :ref:`VUB<VUB storage>`
+   - :ref:`HPC-UGent Tier-2<UGent storage>`
+   - :ref:`KU Leuven/UHasselt<KU Leuven storage>`
+
 .. _VSC home directory:
 
 Home directory

--- a/source/gent/tier2_hardware.rst
+++ b/source/gent/tier2_hardware.rst
@@ -33,6 +33,8 @@ Compute clusters
 For most recent information about the available resources and cluster status, please consult https://www.ugent.be/hpc/en/infrastructure .
 
 
+.. _UGent storage:
+
 Shared storage
 --------------
 

--- a/source/leuven/tier2_hardware/kuleuven_storage.rst
+++ b/source/leuven/tier2_hardware/kuleuven_storage.rst
@@ -22,7 +22,21 @@ The storage is organized according to the :ref:`VSC storage guidelines<data loca
 |                          |        | job only |        |                |
 +--------------------------+--------+----------+--------+----------------+
 
-$VSC_SCRATCH at KU Leuven is not a permament storage. The files older than 28 days are clened regularily.
+$VSC_SCRATCH at KU Leuven is not a permament storage. The files older than 28
+days are cleaned regularly. To be more specific, the automatic file removal is
+based on the moment a file was accessed for the last time. The reasoning
+behind this is that as long as you are actively using a file (so accessing it)
+, the file will not be removed. This policy can however cause confusion when
+files are initially transferred to a scratch directory. If you use for
+instance the `mv` command, the file is not actually accessed. As a result, if
+the last access timestamp of the original file is a long time in the past,
+the file on scratch will be considered to be inactive and automatically
+removed. A similar thing happens when using `rsync` with the option to
+preserve timestamps. Also `Midnight Commander` will always preserve
+timestamps when copying or moving data. To avoid this problem, the
+`cp` command (without `-a` argument) should be used for the
+initial transfer of files to a scratch directory.
+
 For users from other universities, the quota on ``$VSC_HOME`` and ``$VSC_DATA``
 will be determined by the local policy of your home institution as these file
 systems are mounted from there. The path names will be similar with trivial


### PR DESCRIPTION
We had a few (two I believe) cases where users transferred files to $VSC_SCRATCH which were nearly immediately deleted because the access timestamp was not updated. This PR clarifies how the automatic removal works and what the implications are for initially putting files on $VSC_SCRATCH.