### PR TITLE
move 'Match User' section to the end of the config file

### DIFF
--- a/source/access/ssh_config.rst
+++ b/source/access/ssh_config.rst
@@ -24,7 +24,7 @@ To avoid having to specify your VSC private key every time you login, we highly
 recommend linking your key to your VSC-id.
 
 Assuming your private key is ``~/.ssh/id_rsa_vsc``, add the following
-lines to your ``~/.ssh/config``:
+lines to the end of your ``~/.ssh/config``:
 
 ::
 


### PR DESCRIPTION
required in some cases, specifically in macOS with OpenSSH_8.6p1