### PR TITLE
Disable Smart Quotes for dashes

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -75,6 +75,9 @@ exclude_patterns = []
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
 
+# To render double dashes in text as double dashes (and not as an "en dash"):
+smartquotes_action = 'qe'  # instead of default 'qDe'
+
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
By default, the [Docutils Smart Quotes transform](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-smartquotes) converts double dashes in a text block as a single 'en dash'. It seems safer to not do this by default in case one either forgets to escape this in some way or when escaping is not possible or convenient.

What originally made me look into this, is that it caused problems for a user who followed the instructions on
https://docs.vscentrum.be/en/latest/antwerp/SLURM_convert_from_PBS.html#pbs-qsub-command-line-options
There might be a way to just fix it for this particular page, but I think it's safer to just to always avoid creating those 'en dashes'.