### PR TITLE
Add Slurm equivalent for -l nodes=...:ppn=...

### DIFF
--- a/source/antwerp/SLURM_convert_from_PBS.rst
+++ b/source/antwerp/SLURM_convert_from_PBS.rst
@@ -32,6 +32,11 @@ In Slurm, such lines start with ``#SBATCH``.
 PBS/Torque                           Slurm equivalent
 ===================================  =====================
 -L tasks=\ **<X>**:lprocs=\ **<Y>**  --ntasks=\ **<X>** --cpus-per-task=\ **<Y>**
+-l nodes=\ **<N>**:ppn=\ **<P>**     | --nodes=\ **<N>** --ntasks-per-node=\ **<P>**
+                                     |
+                                     | or in the case of e.g. hybrid MPI-OpenMP runs:
+                                     |
+                                     | --nodes=\ **<N>** --ntasks-per-node=\ **<Q>** --cpus-per-task=\ **<P/Q>**
 -l walltime=\ **<time>**             -t **<time>**\ , --time=\ **<time>**
 -N **<jobname>**                     -J **<jobname>**\, --job-name=\ **<jobname>**
 -o **<file>**                        -o **<file template>**\ , --output=\ **<file template>**


### PR DESCRIPTION
Quite some KU Leuven users who were used to PBS have found the "Converting PBS/Torque options to Slurm" page, which is good. But then they focus on the `-L tasks=<X>:lprocs=<Y>` example, which is typically not the right one for converting e.g. their old Genius PBS jobs scripts to Slurm. So this PR adds a `-l nodes=...:ppn=...` example in the hope that KU Leuven users will pick it up.

@RVerschoren I hope this small addition is OK for UAntwerpen as well. In the longer term (e.g. in the future layout for VscDocs) we'll presumably have a better distinction between e.g. common PBS-to-Slurm info and UA- and KU Leuven-specific info.