### PR TITLE
removing mentions to BrENIAC

### DIFF
--- a/source/antwerp/SLURM_UAntwerp.rst
+++ b/source/antwerp/SLURM_UAntwerp.rst
@@ -26,8 +26,8 @@ introductory courses those features of Torque and Moab that resemble Slurm featu
 the most.
 
 Slurm Workload Manager is also used on the clusters at UGent (but with a wrapper that still
-accepts Torque job scripts with some limitations) and will also be the scheduler on Hortense, the
-successor of the BrENIAC Tier-1 system.
+accepts Torque job scripts with some limitations) and will also be the scheduler on the current
+VSC Tier-1 system, Hortense.
 
 Historically, Slurm was an acronym of **S**\imple **L**\inux **U**\tility for
 **R**\esource **M**\anagement. The development started around 2002 at Lawrence Livermore

--- a/source/antwerp/uantwerp_Python.rst
+++ b/source/antwerp/uantwerp_Python.rst
@@ -85,8 +85,7 @@ however a number of remarks specifically for the cluster at the University of An
         a few other performance-critical packages is also available via Conda.) The generic CPU that is used for
         binaries that should run on everything is usually an ancient Pentium 4 or Core CPU. For some code, e.g., 
         dense linear algebra and FFT, using the newer instructions of more recent processors can give a big speed
-        boost for those routines, up to a factor 4 on Leibniz and Vaughan and up to a factor of 7 or so on the
-        Skylake partition of the Tier-1 cluster BrENIAC.
+        boost for those routines, e.g. up to a factor 4 on Leibniz and Vaughan.
       * As Conda effectively installs its own upper layers of a Linux/GNU-system and doesn't use security-sensitive
         libraries from our system, it is up to you to keep it secure by frequently updating. This is particularly 
         important for those packages that make connections of the internet. If you're not using any of these, this


### PR DESCRIPTION
Tiny modification to remove the mention of BrENIAC in two pages.
Because BrENIAC is decomissioned, users cannot reproduce the mentioned speedup figures, so such performance comparisons will loose their meaning over time.