### PR TITLE
fix links to VSC website in Access section

### DIFF
--- a/source/access/index.rst
+++ b/source/access/index.rst
@@ -18,11 +18,11 @@ Your VSC account gives you access to most of the VSC Tier-2 infrastructure,
 though for some more specialized hardware you may have to ask access separately.
 The rationale is that  we want to ensure that that specialized (usually rather
 expensive) hardware is used efficiently for the type of applications it was
-purchased for.  Contact your `local VSC coordinator <get in touch>`_ to arrange
+purchased for.  Contact your `local VSC coordinator <get in touch_>`_ to arrange
 access when required.
 
 For the main Tier-1 compute cluster you need to submit a
-`project application <tier-1 project application>`_ (or you should be
+`project application <tier-1 project application_>`_ (or you should be
 covered by a project application within your research group).
 
 Before you apply for VSC account, it is useful to first check whether
@@ -34,7 +34,7 @@ laptop is sufficient. The pages on the :ref:`tier1 hardware` and
 :ref:`tier2 hardware` give a high-level description of our
 infrastructure. You can find more detailed information in the user
 documentation on the user portal. When in doubt, you can also contact
-your `local support team <get in touch>`_. This does not require a VSC account.
+your `local support team <get in touch_>`_. This does not require a VSC account.
 
 VSC Accounts
 ============

--- a/source/access/index.rst
+++ b/source/access/index.rst
@@ -5,7 +5,7 @@
 ######################################
 
 In order to use the infrastructure of the VSC, you need a VSC user-ID,
-also called a VSC account. Check the `VSC website <eligible users>`_
+also called a VSC account. Check the `VSC website <eligible users_>`_
 for conditions.
 
 All VSC-accounts start with the letters ``vsc`` followed by a

--- a/source/access/using_the_xming_x_server_to_display_graphical_programs.rst
+++ b/source/access/using_the_xming_x_server_to_display_graphical_programs.rst
@@ -11,7 +11,7 @@ freely available.
 Installing Xming
 ----------------
 
-#. Download the Xming installer from the `Xming web site`_.
+#. Download the Xming installer from the `Xming website`_.
 
 #. Either install Xming from the **Public Domain Releases** (free) or
    from the **Website Releases** (after a donation) on the website.

--- a/source/access/windows_client.rst
+++ b/source/access/windows_client.rst
@@ -67,8 +67,7 @@ system of the cluster.
 
 |Recommended| Use the X server included in :ref:`MobaXterm <access using mobaxterm>`.
 
-Alternatively, you can install an X server such as `Xming <Xming web site>`_ on
-Windows as well.
+Alternatively, you can install an X server such as `Xming`_ on Windows as well.
 
 .. toctree::
 

--- a/source/access/windows_client.rst
+++ b/source/access/windows_client.rst
@@ -67,7 +67,8 @@ system of the cluster.
 
 |Recommended| Use the X server included in :ref:`MobaXterm <access using mobaxterm>`.
 
-Alternatively, you can install an X server such as `Xming`_ on Windows as well.
+Alternatively, you can install an X server such as `Xming <Xming website_>`_ on
+Windows as well.
 
 .. toctree::
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -401,10 +401,9 @@ rst_prolog += """
 .. _VirtualGL: https://en.wikipedia.org/wiki/VirtualGL
 .. _VSC account page: https://account.vscentrum.be/
 .. _VSC training: https://www.vscentrum.be/training
-.. _VSC training: https://www.vscentrum.be/training
 .. _WinSCP docs: https://winscp.net/eng/docs/start
 .. _worker documentation: http://worker.readthedocs.io/en/latest/
 .. _worker framework documentation: https://worker.readthedocs.io/en/latest/
 .. _www.globus.org: https://www.globus.org
-.. _Xming web site: http://www.straightrunning.com/XmingNotes/
+.. _Xming: http://www.straightrunning.com/XmingNotes/
 """

--- a/source/conf.py
+++ b/source/conf.py
@@ -405,5 +405,5 @@ rst_prolog += """
 .. _worker documentation: http://worker.readthedocs.io/en/latest/
 .. _worker framework documentation: https://worker.readthedocs.io/en/latest/
 .. _www.globus.org: https://www.globus.org
-.. _Xming: http://www.straightrunning.com/XmingNotes/
+.. _Xming website: http://www.straightrunning.com/XmingNotes/
 """

--- a/styleguide.md
+++ b/styleguide.md
@@ -191,7 +191,7 @@ end. This will disable the target for this link. *e.g.*
 `` `link_label <https://url.com>`__ ``
 
 URLs that are used multiple times can be defined a single time in
-[`conf.py`](source/conf.py) with their own explicit target that can be reused
+[`conf.py`](source/conf.py) as a named reference that can be reused
 in the documentation files.
 
 ```
@@ -200,10 +200,22 @@ in the documentation files.
 .. _VSC account page: https://account.vscentrum.be/
 ```
 
+Then you can inject that link directly in the text and it will be rendered as a
+link to the defined URL using the name of the reference as label.
+
+
 ```
 [example.rst]
 
 Check the `VSC account page`_.
+```
+
+Using the URL from a named reference but changing its label is also possible.
+
+```
+[example.rst]
+
+Check `your account page <VSC account page_>`_.
 ```
 
 ### Link Buttons


### PR DESCRIPTION
A few links to the VSC website in the access section are broken (thanks to @jantur3k for catching those :beers:)  . They use URLs from a named reference and lack a `_` to get the reference interpreted as such.

This is a weird error that results in a broken link but does not triger any warning or error at compile time. That's why it went through the cracks.

I'm also updating the styleguide to cover this case.