### PR TITLE
Revamp the Genius to Rocky 8 page

### DIFF
--- a/source/leuven/genius_2_rocky.rst
+++ b/source/leuven/genius_2_rocky.rst
@@ -61,7 +61,7 @@ If you only have a Conda environment working on Genius, it's best to create a ne
   
 In order to install miniconda in a new directory you can ::
 
-   bash Miniconda3-latest-Linux-x86_64.sh -b -p $VSC_DATA/miniconda3/rocky
+   bash Miniconda3-latest-Linux-x86_64.sh -b -p $VSC_DATA/miniconda3-rocky
    export PATH="${VSC_DATA}/miniconda3-rocky/bin:${PATH}
 
 You can then use this Conda environment after the migration. You can prepare this on the test nodes.
@@ -71,19 +71,20 @@ You can then use this Conda environment after the migration. You can prepare thi
 
 Impact on starting jobs on Genius and wICE
 ------------------------------------------
-In order to minimize the changes you need to make to your jobscripts, an appropriate module path (``$MODULEPATH``) will be set by default at the start of your job of the the migration of Genius to Rocky 8 OS. This new module path will now contain all toolchain versions, so all the modules, starting from 2018a on Genius and starting from 2021a on wICE. This is an important change! Previously the modulepath was set to a single toolchain, that would not change over time. You might have set a module path in your jobscripts to refer to newer toolchains. Module use/unuse should now only be needed in exceptional cases.
+Previously the modulepath was set to a single toolchain, that would not change over time. But, instead of working with such a single default, unchanging, modulepath, refering to a single default toolchain (e.g. 2018a on Genius), a new approach is taken. After the migration, the partition-specific modules will be automatically exposed when a job starts on the compute node(s).
+
+In order to minimize the changes to your jobscripts, an appropriate module path (``$MODULEPATH``) is set by default at the start of your job. This new module path contains all toolchain versions specific to a partition. On Genius, all modelues since 2018a will be avaialbe, and on wICE, all modules starting from 2021a. 
+
+As a result of this change, you do not need to do ``module use/unuse`` in your jobscripts. Such lines can be perfectly removed from your jobscript (unless you deal with an exceptional case).
 
 .. note::
 
    If you have set a module path explicitly in your jobscript, you can remove it from your jobscript or change it to the module path for Rocky 8.
 
-
-
 Using cluster modules
 ~~~~~~~~~~~~~~~~~~~~~
 
-Instead of working with a single default, unchanging, modulepath, refering to a single default toolchain, a new approach is taken. Each cluster partition will have a so called cluster module that sets the ``$MODULEPATH`` that is valid for the specific nodes in the cluster partition. The cluster module will detect the underlying CPU architecture and uses this for setting the path correctly.
-
+Each cluster partition will have a so called cluster module that sets the ``$MODULEPATH`` that is valid for the specific nodes in the cluster partition. The cluster module will detect the underlying CPU architecture and uses this for setting the path correctly.
 
 .. _check_available_software:
 
@@ -110,7 +111,7 @@ Loading any of this modules on the login node::
 
    $ module load cluster/genius/batch
 
-will set the module path for the modules that are applicable for the Genius ``batch`` partition::
+will set the module path for the modules that are applicable for the Genius ``batch`` partition. Similarly,::
 
    $ module load cluster/wice/batch
 
@@ -118,4 +119,3 @@ will set the the module path of the wICE ``batch`` partition. When you do this o
 
    $ module avail
    $ module spider cp2k
-

--- a/source/leuven/genius_2_rocky.rst
+++ b/source/leuven/genius_2_rocky.rst
@@ -9,7 +9,7 @@ running on :ref:`wICE <wice hardware>` nodes. This update is strictly
 necessary because CentOS 7 will be
 `discontinued <https://www.redhat.com/en/engage/migrate-from-centos-20230404>`__
 and this poses security concerns. We have tried to make the migration as
-transparently as possible for users, but still there are a few changes to take
+transparent as possible for users, but still there are a few changes to take
 into account. The first important item is that the way you can search for and
 load modules has changed. This probably affects all users and you are urged
 to carefully read the section on :ref:`centrally installed modules <impact_on_central_software>`.
@@ -85,7 +85,7 @@ available. The *cluster* module is always available and you can see which
 versions can be loaded by executing ``module avail cluster``.
 
 On the login nodes and inside a job environment, the correct version of the
-cluster will be loaded automatically. This means that for these cases, you do
+cluster module will be loaded automatically. This means that for these cases, you do
 not need to take any special action: the modules from the appropriate software
 stack will be the only ones available to you. As a result of this change, you
 do not need to do ``module use/unuse`` in your jobscripts. Such lines can be
@@ -114,7 +114,8 @@ case).
 A common scenario is that you want to search through the installed modules for
 a software package you need, while you are on a login node. There are two ways
 this can be done. In the example below we assume the commands are executed on
-a Genius login node.
+a Genius login node. The software package that is used as an example is
+called ``CP2K``.
 
 The first option is to load the cluster module corresponding to the node where
 you eventually want to use a certain software package. If you are planning to
@@ -126,7 +127,7 @@ run jobs on the wICE batch partition, the commmand is:
 
 Note that the previously loaded cluster module will be automatically unloaded:
 at most 1 cluster module can be loaded at a time. Now you can search for
-modules containing `CP2K` by executing (the search is not case sensitive):
+modules containing ``CP2K`` by executing (the search is not case sensitive):
 
 .. code-block:: shell
 
@@ -167,8 +168,8 @@ to ``$MODULEPATH`` in case a cluster module would be loaded. An example is:
         $ module spider CP2K/8.2-intel-2021a
    -------------------------------------
 
-As suggested as part of the output, you can obtain more information about one
-of the available versions of the CP2K module by executing:
+As suggested by the output, you can obtain more information about one
+of the available versions of the ``CP2K`` module by executing:
 
 .. code-block:: shell
 
@@ -204,7 +205,9 @@ available. For more information about ``module spider``, have a look at the
    will be available, and on wICE, all modules starting from 2021a. For a few
    legacy modules, installation is impossible on a recent operating system. In
    such a case, it is recommended to use a replacement module from a newer
-   toolchain version.
+   toolchain version. Alternatively you can consider to run your legacy
+   software inside a container, but this is only the best option in some
+   specific cases.
 
 .. _manually_modifying_modulepath:
 
@@ -212,9 +215,9 @@ Manually modifying the modulepath
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As discussed in the previous section, the recommended approach to set your
-``$MODULEPATH`` environment variable so modules from the correct software
-stack are available, is by using the cluster module. It is however also
-possible to manually modify the path where modules are searched.
+``$MODULEPATH`` environment variable, is by using the cluster module. This
+will make modules from the correct software stack available. It is however
+also possible to manually modify the path where modules are searched.
 
 Each software stack is located in a directory with the following hierarchical
 structure::
@@ -248,20 +251,23 @@ Impact on user-installed software
 If you have installed a software package yourself in your own account, and you
 did this on a Genius CentOS 7 node, it must be recompiled on Genius on a node
 with the new OS. This can be done on one of the available test nodes. Please
-request access to the lpt2_rocky8_pilot group.
+request access to the ``lpt2_rocky8_pilot`` group.
 
 Conda environments
 ----------------------------
 The Conda environment you installed might need reinstallations. If you already
 have a Conda environment that works on wICE, it also should work on Genius
 after the migration. If you only have a Conda environment working on Genius,
-it is best to create a new Conda installation. In this case, it is recommended
-to recreate your environment for full compatibility with the new OS. Best practice
-is to choose a new installation folder with explicit mention of the new OS, e.g.::
+it is best to create a new Conda installation. If you used ``pip`` to install
+software inside your conda environment and ``pip`` has compiled the package from
+source, you certainly need to recreate your conda environment. In this case,
+it is recommended to recreate your environment for full compatibility with the
+new OS. Best practice is to choose a new installation folder with explicit
+mention of the new OS, e.g.::
 
-   ${VSC_DATA}/miniconda3-rocky
+   ${VSC_DATA}/miniconda3-rocky8
 
 In order to install miniconda in a new directory you can ::
 
-   bash Miniconda3-latest-Linux-x86_64.sh -b -p $VSC_DATA/miniconda3-rocky
-   export PATH="${VSC_DATA}/miniconda3-rocky/bin:${PATH}
+   bash Miniconda3-latest-Linux-x86_64.sh -b -p ${VSC_DATA}/miniconda3-rocky8
+   export PATH="${VSC_DATA}/miniconda3-rocky8/bin:${PATH}

--- a/source/leuven/genius_2_rocky.rst
+++ b/source/leuven/genius_2_rocky.rst
@@ -96,8 +96,8 @@ case).
 
    The appropriate cluster module is only loaded automatically inside a job
    environment and on the login nodes. In other cases (for example when you
-   ssh directly into a node), you will need to first load a cluster module in
-   order to make the correct modules available.
+   ssh directly into a node), you will need to first load a cluster module
+   yourself in order to make the correct modules available.
 
 .. warning::
 
@@ -145,7 +145,7 @@ to ``$MODULEPATH`` in case a cluster module would be loaded. An example is:
 
 .. code-block::
 
-   $ module --ignore-cache spider CP2K
+   $ module spider CP2K
    -------------------------------------
      CP2K:
    -------------------------------------
@@ -191,10 +191,10 @@ of the available versions of the CP2K module by executing:
       cluster/wice/batch
       ...
 
-This command which cluster modules will make the ``CP2K/8.2-intel-2021a``
-available. As discussed earlier, loading ``cluster/wice/batch`` is one example
-of a cluster module that suffices to make ``CP2K/8.2-intel-2021a`` available.
-For more information about ``module spider``, have a look at the
+This command shows which cluster modules will make the ``CP2K/8.2-intel-2021a``
+module available. As discussed earlier, loading ``cluster/wice/batch`` is one
+example of a cluster module that suffices to make ``CP2K/8.2-intel-2021a``
+available. For more information about ``module spider``, have a look at the
 `Lmod documentation page <https://lmod.readthedocs.io/en/latest/135_module_spider.html>`__
 
 .. note::
@@ -214,7 +214,7 @@ Manually modifying the modulepath
 As discussed in the previous section, the recommended approach to set your
 ``$MODULEPATH`` environment variable so modules from the correct software
 stack are available, is by using the cluster module. It is however also
-possible to manually the path where modules are searched.
+possible to manually modify the path where modules are searched.
 
 Each software stack is located in a directory with the following hierarchical
 structure::

--- a/source/leuven/genius_2_rocky.rst
+++ b/source/leuven/genius_2_rocky.rst
@@ -1,121 +1,267 @@
 .. _genius_2_rocky:
 
-Genius migration to Rocky 8
-===========================
-The :ref:`Genius <genius hardware>` operating system will be changed from CentOS 7 to Rocky 8. This is the same OS as currently running on :ref:`wICE <wice hardware>`.
-The migration will be done on September 25.
-Sofware installed on wICE is not impacted, because there is no change of OS on wICE.
+Migration of Genius to Rocky 8
+==============================
+
+The operating system on :ref:`Genius <genius hardware>` nodes will be updated
+from CentOS 7 to Rocky 8, the same operating system that is currently
+running on :ref:`wICE <wice hardware>` nodes. This update is strictly
+necessary because CentOS 7 will be
+`discontinued <https://www.redhat.com/en/engage/migrate-from-centos-20230404>`__
+and this poses security concerns. We have tried to make the migration as
+transparently as possible for users, but still there are a few changes to take
+into account. The first important item is that the way you can search for and
+load modules has changed. This probably affects all users and you are urged
+to carefully read the section on :ref:`centrally installed modules <impact_on_central_software>`.
+The second item is that users that installed their own software (this includes
+conda environments), will need to reinstall the software for the new OS. More
+details are outlined :ref:`below <impact_on_user_installed_software>`. If you
+still encounter problems *after* reading this documentation page, you can
+contact the :ref:`support team <user support VSC>`.
 
 .. note::
 
-   Test nodes are available. If you want to test your software or your Conda environment you can do so as follows:
+   Until the migration takes place on September 25, some test nodes are
+   available. If you want to test your software or your Conda environment
+   you can do so as follows:
 
    On the `VSC account page`_, request access to the group ``lpt2_rocky8_pilot``.
-   Once approved by the admins, you can submit jobs to the reserved Rocky 8 nodes by specifying the option ``--reservation=genius_rocky8_pilot``.
-   To switch to the modules that have already been reinstalled for Rocky 8, first execute::
-
-      module load cluster/genius/batch
-     
-   for the CPU nodes (which are inside the ``batch`` partition), and::
-
-      module load cluster/genius/gpu_p100
-     
-   for the GPU node (which is in the ``gpu_p100`` partition).
-   This will set your module path to point to the new modules for Rocky 8.
+   Once approved by the admins, you can submit jobs to the reserved Rocky 8
+   nodes by specifying the option ``--reservation=genius_rocky8_pilot`` to
+   your submit command.
 
 
 .. _impact_on_central_software:
 
-Impact on centrally installed modules
--------------------------------------
-Current Genius software needs to be reinstalled because dependencies on the OS libraries will break the existing software.
-All centrally installed modules which have seen recent use, starting from 2018a toolchains, will be re-installed (as far as possible). Older toolchains will not be migrated.
-Unused modules are not migrated automatically, but we strongly advise to use modules in the most recent toolchains (2021a).
+Searching and loading centrally installed modules
+-------------------------------------------------
 
-In order to distinguish between the old CentOS 7 and the new Rocky 8 software installations, an additional level is introduced in the ``/apps`` hierarchy::
+Introduction
+~~~~~~~~~~~~
+
+A lot of scientific software is centrally available on the VSC clusters. To
+avoid conflicts between different software packages, the installations are
+offered as modules (specifically, the `Lmod system <https://lmod.readthedocs.io/en/latest/>`__
+is used). The executables, libraries, headers, ... of a certain module can only
+be used after that module has been loaded. By loading a certain set of modules,
+you can easily set up an environment that has precisely the software you need.
+
+When an HPC cluster is not completely homogeneous (for instance there are
+differences regarding architecture or operating system between nodes), it is
+important to use the appropriate modules in your jobs. Using a module that is
+not suited for the node on which the job is running, can give suboptimal
+performance, or even completely fail to work. This is why modules are
+organized in different *software stacks*, differentiated by the operating
+system, the architecture, and the toolchain version. The good news is that in
+general you do not need to worry too much about this, as in most cases the
+correct software stack will be made available in a job automatically thanks
+to the *cluster modules*, as explained in the :ref:`next section <cluster_module>`.
+If you are interested in more technical details, you can read the section on
+:ref:`manually modifying the modulepath <manually_modifying_modulepath>`,
+which is oriented towards advanced users.
+
+.. _cluster_module:
+
+The cluster module
+~~~~~~~~~~~~~~~~~~
+
+One crucial point to understand, is that a module is *available* only if it is
+located inside a directory contained in the ``$MODULEPATH`` environment
+variable. The ``$MODULEPATH`` environment variable is a colon-separated list of
+directories, and you can list all modules located inside those directories
+with the ``module avail`` command. The different software stacks mentioned
+earlier are located in different directories (see the
+:ref:`next section <manually_modifying_modulepath>` for more details), so in
+order to make sure you are loading modules from the appropriate software stack,
+you need to make sure your ``$MODULEPATH`` variable contains the appropriate
+paths for the node where you want to use a module.
+
+Because working with the different directories containing different software
+stacks is cumbersome, we advise users to rely on the *cluster* module to set
+the ``$MODULEPATH`` variable. The *cluster* module can be handled identically
+as other modules, but instead of making executables or libraries available,
+its only purpose is to set up your environment to make the correct modules
+available. The *cluster* module is always available and you can see which
+versions can be loaded by executing ``module avail cluster``.
+
+On the login nodes and inside a job environment, the correct version of the
+cluster will be loaded automatically. This means that for these cases, you do
+not need to take any special action: the modules from the appropriate software
+stack will be the only ones available to you. As a result of this change, you
+do not need to do ``module use/unuse`` in your jobscripts. Such lines can be
+perfectly removed from your jobscript (unless you deal with an exceptional
+case).
+
+.. note::
+
+   The appropriate cluster module is only loaded automatically inside a job
+   environment and on the login nodes. In other cases (for example when you
+   ssh directly into a node), you will need to first load a cluster module in
+   order to make the correct modules available.
+
+.. warning::
+
+   If your jobscript contains the command ``module --force purge``, the
+   cluster module will be unloaded and your ``$MODULEPATH`` will not contain
+   the directory with the appropriate software stack. It will be necessary to
+   load the correct cluster module or set your ``$MODULEPATH`` in another way.
+   This is why we advise to not use ``module --force purge`` in your jobs,
+   unless you are well aware of the consequences. Note that it is ok to
+   execute ``module purge``, since the cluster module is a
+   `sticky module <https://lmod.readthedocs.io/en/latest/240_sticky_modules.html>`__
+   , which means it is not unloaded with ``module purge``.
+
+A common scenario is that you want to search through the installed modules for
+a software package you need, while you are on a login node. There are two ways
+this can be done. In the example below we assume the commands are executed on
+a Genius login node.
+
+The first option is to load the cluster module corresponding to the node where
+you eventually want to use a certain software package. If you are planning to
+run jobs on the wICE batch partition, the commmand is:
+
+.. code-block:: shell
+
+   $ module load cluster/wice/batch
+
+Note that the previously loaded cluster module will be automatically unloaded:
+at most 1 cluster module can be loaded at a time. Now you can search for
+modules containing `CP2K` by executing (the search is not case sensitive):
+
+.. code-block:: shell
+
+   $ module avail CP2K
+   -- /apps/leuven/rocky8/icelake/2021a/modules/all --
+      CP2K/8.2-foss-2021a         Libint/2.6.0-GCC-10.3.0-lmax-6-cp2k
+      CP2K/8.2-intel-2021a (D)    Libint/2.6.0-iimpi-2021a-lmax-6-cp2k
+      Libint/2.6.0-intel-compilers-2021.2.0-lmax-6-cp2k (D)
+
+A second approach to search for installed software, is to use the
+``module spider`` command. In contrast to the ``module avail`` command, with
+``module spider`` Lmod will not only search for available modules (meaning
+modules inside directories included in the current value of ``$MODULEPATH``),
+but additionally will take into account additional entries that would be added
+to ``$MODULEPATH`` in case a cluster module would be loaded. An example is:
+
+.. code-block::
+
+   $ module --ignore-cache spider CP2K
+   -------------------------------------
+     CP2K:
+   -------------------------------------
+   Description:
+         CP2K is a freely available (GPL) program, ...
+   Versions:
+           CP2K/5.1-intel-2018a
+           CP2K/6.1-foss-2018a
+           CP2K/6.1-intel-2018a
+           CP2K/7.1-foss-2019b
+           CP2K/7.1-intel-2019b
+           CP2K/8.2-foss-2021a
+           CP2K/8.2-intel-2021a
+   -------------------------------------
+     For detailed information about a specific "CP2K" package (including how
+     to load the modules) use the module's full name.
+     Note that names that have a trailing (E) are extensions provided by other
+     modules. For example:
+        $ module spider CP2K/8.2-intel-2021a
+   -------------------------------------
+
+As suggested as part of the output, you can obtain more information about one
+of the available versions of the CP2K module by executing:
+
+.. code-block:: shell
+
+   $ module spider CP2K/8.2-intel-2021a
+
+   -------------------------------------
+     CP2K: CP2K/8.2-intel-2021a
+   -------------------------------------
+       Description:
+         CP2K is a freely available (GPL) program, ...
+
+
+    You will need to load all module(s) on any one of the lines below before
+    the "CP2K/8.2-intel-2021a" module is available to load
+
+      cluster/genius/amd
+      cluster/genius/amd_long
+      cluster/genius/batch
+      ...
+      cluster/wice/batch
+      ...
+
+This command which cluster modules will make the ``CP2K/8.2-intel-2021a``
+available. As discussed earlier, loading ``cluster/wice/batch`` is one example
+of a cluster module that suffices to make ``CP2K/8.2-intel-2021a`` available.
+For more information about ``module spider``, have a look at the
+`Lmod documentation page <https://lmod.readthedocs.io/en/latest/135_module_spider.html>`__
+
+.. note::
+
+   In contrast to previous behavior, modules from different toolchain versions
+   will now be available automatically. On Genius, all modules since 2018a
+   will be available, and on wICE, all modules starting from 2021a. For a few
+   legacy modules, installation is impossible on a recent operating system. In
+   such a case, it is recommended to use a replacement module from a newer
+   toolchain version.
+
+.. _manually_modifying_modulepath:
+
+Manually modifying the modulepath
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As discussed in the previous section, the recommended approach to set your
+``$MODULEPATH`` environment variable so modules from the correct software
+stack are available, is by using the cluster module. It is however also
+possible to manually the path where modules are searched.
+
+Each software stack is located in a directory with the following hierarchical
+structure::
 
    /apps/leuven/${VSC_OS_LOCAL}/${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX}/TOOLCHAIN_VERSION/modules/all
 
-e.g.::
+e.g.:
 
-   /apps/leuven/rocky8/skylake/2018a/modules/all 
-  
-This convention is in line with other VSC sites and will also be used on wICE and future clusters.
+.. code-block:: shell
 
+   /apps/leuven/rocky8/skylake/2018a/modules/all
+
+This convention is in line with other VSC sites and will also be used on wICE
+and future clusters. In order to add such a directory to your modulepath, the
+following command can be used:
+
+.. code-block:: shell
+
+   module use /apps/leuven/rocky8/skylake/2018a/modules/all
+
+To remove the entry again:
+
+.. code-block:: shell
+
+   module unuse /apps/leuven/rocky8/skylake/2018a/modules/all
 
 .. _impact_on_user_installed_software:
 
 Impact on user-installed software
 ---------------------------------
-If you have installed a software package yourself in your own account, and you did this on a Genius CentOS 7 node, it must be recompiled on Genius on a node with the new OS.
-This can be done on one of the available test nodes. Please request access to the lpt2_rocky8_pilot group.
+If you have installed a software package yourself in your own account, and you
+did this on a Genius CentOS 7 node, it must be recompiled on Genius on a node
+with the new OS. This can be done on one of the available test nodes. Please
+request access to the lpt2_rocky8_pilot group.
 
-.. _impact_on_conda:
-
-Impact on Conda environments
+Conda environments
 ----------------------------
-The Conda environment you installed might need reinstallations. If you already have a Conda environment that works on wICE, it also should work on Genius after the migration.
-If you only have a Conda environment working on Genius, it's best to create a new Conda installation. In this case, it is recommended to recreate your environment for full compatibility with the new OS. Best practice is to choose a new installation folder with explicit mention of the new OS, e.g. ::
+The Conda environment you installed might need reinstallations. If you already
+have a Conda environment that works on wICE, it also should work on Genius
+after the migration. If you only have a Conda environment working on Genius,
+it is best to create a new Conda installation. In this case, it is recommended
+to recreate your environment for full compatibility with the new OS. Best practice
+is to choose a new installation folder with explicit mention of the new OS, e.g.::
 
    ${VSC_DATA}/miniconda3-rocky
-  
+
 In order to install miniconda in a new directory you can ::
 
    bash Miniconda3-latest-Linux-x86_64.sh -b -p $VSC_DATA/miniconda3-rocky
    export PATH="${VSC_DATA}/miniconda3-rocky/bin:${PATH}
-
-You can then use this Conda environment after the migration. You can prepare this on the test nodes.
-
-
-.. _impact_on_starting_jobs:
-
-Impact on starting jobs on Genius and wICE
-------------------------------------------
-Previously the modulepath was set to a single toolchain, that would not change over time. But, instead of working with such a single default, unchanging, modulepath, refering to a single default toolchain (e.g. 2018a on Genius), a new approach is taken. After the migration, the partition-specific modules will be automatically exposed when a job starts on the compute node(s).
-
-In order to minimize the changes to your jobscripts, an appropriate module path (``$MODULEPATH``) is set by default at the start of your job. This new module path contains all toolchain versions specific to a partition. On Genius, all modelues since 2018a will be avaialbe, and on wICE, all modules starting from 2021a. 
-
-As a result of this change, you do not need to do ``module use/unuse`` in your jobscripts. Such lines can be perfectly removed from your jobscript (unless you deal with an exceptional case).
-
-.. note::
-
-   If you have set a module path explicitly in your jobscript, you can remove it from your jobscript or change it to the module path for Rocky 8.
-
-Using cluster modules
-~~~~~~~~~~~~~~~~~~~~~
-
-Each cluster partition will have a so called cluster module that sets the ``$MODULEPATH`` that is valid for the specific nodes in the cluster partition. The cluster module will detect the underlying CPU architecture and uses this for setting the path correctly.
-
-.. _check_available_software:
-
-Check available software
-~~~~~~~~~~~~~~~~~~~~~~~~
-On the login node you will be able to load the different available cluster modules (only for experimentation, not for actual computing). In order to do this you can query the available cluster moduels with::
-
-   $ module avail
-
-this wil show the available cluster modules::
-
-   --------------------------- /apps/leuven/etc/modules ---------------------------
-   cluster/default
-   cluster/genius/amd_long               (S)
-   cluster/genius/amd                    (S)
-   cluster/genius/batch_debug            (S)
-   cluster/genius/batch_long             (S)
-   cluster/genius/batch                  (S)
-   ...
-   cluster/wice/batch
-   ...
-
-Loading any of this modules on the login node::
-
-   $ module load cluster/genius/batch
-
-will set the module path for the modules that are applicable for the Genius ``batch`` partition. Similarly,::
-
-   $ module load cluster/wice/batch
-
-will set the the module path of the wICE ``batch`` partition. When you do this on the login node you can examine wich modules are available with the regular commands, e.g.::
-
-   $ module avail
-   $ module spider cp2k


### PR DESCRIPTION
I have made some quite aggressive changes to the Genius to Rocky 8 page, I hope everyone is ok with that. My main objectives are:
* Provide a more extensive description of how the cluster module works
* Make sure most of this page remains valid _after_ the migration, since I think that the discussion on the cluster module should be permanent and not temporary.

I have a few remarks
* There is some overlap with other pages such as https://docs.vscentrum.be/software/software_stack.html or https://docs.vscentrum.be/gent/setting_up_the_environment_using_lmod_at_the_hpc_ugent_clusters.html# In the long term it would be good to merge it in there (although there can be some CUE issues)
* In a few other places, we recommend to execute `module use` to adapt the modulepath. This will no longer be needed after the migration and those pages should be adapted then.
* We now recommend users to have a separate conda installation with `-rocky` as suffix. On the wICE page however, we recommend the `-wice` suffix, so maybe we should try to discuss this at some point to make things more consistent (I would also prefer `-rocky8`, to avoid issues in the next OS update).