### PR TITLE
Bugfix/slurm args

### DIFF
--- a/source/leuven/credits.rst
+++ b/source/leuven/credits.rst
@@ -112,7 +112,8 @@ we charge 10 000 Slurm credits per hour.
 
 An example of a job running on multiple nodes and cores is given below::
 
-   $ sbatch --account=lp_astrophysics_014 --clusters=genius --nodes=2 --ntasks-per-node=36 simulation_3415.slurm
+   $ sbatch --account=lp_astrophysics_014 --clusters=genius --nodes=2 \
+            --ntasks-per-node=36 simulation_3415.slurm
 
 For Genius thin nodes we have ``TRESBillingWeights=CPU=4.62963``.
 If this job finishes in 2.5 hours (i.e., walltime is 150 minutes), the user

--- a/source/leuven/credits.rst
+++ b/source/leuven/credits.rst
@@ -52,7 +52,7 @@ it consumes. Two distinct TRES are the number of CPU cores and GPU devices.
 Different types of CPU and GPU nodes are given different weights 
 (``TRESBillingWeights``) which you can retrieve as follows for e.g. wICE::
 
-   scontrol show partitions -M wice
+   scontrol show partitions --clusters=wice
 
 As an example, for a GPU node, the weights are configured as::
 
@@ -112,7 +112,7 @@ we charge 10 000 Slurm credits per hour.
 
 An example of a job running on multiple nodes and cores is given below::
 
-   $ sbatch -A lp_astrophysics_014 -M genius -N 2 -ntasks-per-node=36 simulation_3415.slurm
+   $ sbatch --account=lp_astrophysics_014 --clusters=genius --nodes=2 --ntasks-per-node=36 simulation_3415.slurm
 
 For Genius thin nodes we have ``TRESBillingWeights=CPU=4.62963``.
 If this job finishes in 2.5 hours (i.e., walltime is 150 minutes), the user

--- a/source/leuven/genius_quick_start.rst
+++ b/source/leuven/genius_quick_start.rst
@@ -49,7 +49,8 @@ Submitting a regular compute job boils down to specifying the required number of
 nodes, cores-per-node, memory and walltime. You may e.g. request two full nodes like
 this::
 
-   $ sbatch --account=lp_myproject --clusters=genius --time=2:00:00 --nodes=2 --ntasks-per-node=36 myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=genius --time=2:00:00 --nodes=2 \
+            --ntasks-per-node=36 myjobscript.slurm
 
 You may also request only a part of the resources on a node.
 For instance, to test a multi-threaded application which performs optimally using 4 cores,
@@ -57,7 +58,8 @@ you may submit your job like this::
 
    $ sbatch --account=lp_myproject --clusters=genius --time=2:00:00 --ntasks=4 myjobscript.slurm
    # or
-   $ sbatch --account=lp_myproject --clusters=genius --time=2:00:00 --ntasks=1 --cpus-per-task=4 myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=genius --time=2:00:00 --ntasks=1 \
+            --cpus-per-task=4 myjobscript.slurm
 
 .. note::
 
@@ -122,17 +124,20 @@ different users.
 However, every user will have exclusive access to the number of GPUs requested. 
 If you want to use only 1 GPU of type P100 you can submit for example like this::
 
-   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=9 --gpus-per-node=1 --partition=gpu_p100 myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=9 \
+            --gpus-per-node=1 --partition=gpu_p100 myjobscript.slurm
   
 Note that in case of 1 GPU you have to request 9 cores. 
 In case you need more GPUs you have to multiply the 9 cores with the number of GPUs 
 requested, so in case of for example 3 GPUs you will have to specify this::
 
-   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=27 --gpus-per-node=3 -p gpu_p100 myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=27 \
+            --gpus-per-node=3 -p gpu_p100 myjobscript.slurm
 
 To specifically request V100 GPUs, you can submit for example like this::
 
-   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=4 --gpus-per-node=1 --mem-per-cpu=20000M --partition=gpu_v100 myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=4 \
+            --gpus-per-node=1 --mem-per-cpu=20000M --partition=gpu_v100 myjobscript.slurm
   
 For the V100 type of GPU, it is required that you request 4 cores for each GPU. 
 Also notice that these nodes offer a much larger amount of CPU memory.
@@ -146,7 +151,8 @@ The big memory nodes are located in the ``bigmem`` and ``bigmem_long`` partition
 In case of the big memory nodes it is also important to add your memory requirements, 
 for example::
 
-   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=36 --mem-per-cpu=20000M --partition=bigmem myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=36 \
+            --mem-per-cpu=20000M --partition=bigmem myjobscript.slurm
 
 
 .. _submit_genius_amd:
@@ -158,7 +164,8 @@ Besides specifying the partition, it is also important to note that the default 
 per core in this partition is 3800 MB, and each node contains 64 cores.
 For example, to request two full nodes::
 
-   $ sbatch --account=lp_my_project --clusters=genius --nodes=2 --ntasks-per-node=64 --partition=amd myjobscript.slurm 
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=2 --ntasks-per-node=64 \
+            --partition=amd myjobscript.slurm 
 
 
 .. _submit_genius_debug:
@@ -179,8 +186,10 @@ A few restrictions apply to a debug job:
 
 To run a debug job for 20 minutes on two CPU nodes, you would use::
 
-   $ sbatch --account=lp_my_project --clusters=genius --nodes=2 --ntasks-per-node=36 --partition=batch_debug --time=20:00 myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=2 --ntasks-per-node=36 \
+            --partition=batch_debug --time=20:00 myjobscript.slurm
 
 To run a debug job for 15 minutes on a GPU node, you would use::
 
-   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=9 --gpus-per-node=1 --partition=gpu_p100_debug --time=15:00 myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=9 \
+            --gpus-per-node=1 --partition=gpu_p100_debug --time=15:00 myjobscript.slurm

--- a/source/leuven/genius_quick_start.rst
+++ b/source/leuven/genius_quick_start.rst
@@ -49,15 +49,15 @@ Submitting a regular compute job boils down to specifying the required number of
 nodes, cores-per-node, memory and walltime. You may e.g. request two full nodes like
 this::
 
-   $ sbatch -A lp_myproject -M genius -t 2:00:00 --nodes=2 --ntasks-per-node=36 myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=genius --time=2:00:00 --nodes=2 --ntasks-per-node=36 myjobscript.slurm
 
 You may also request only a part of the resources on a node.
 For instance, to test a multi-threaded application which performs optimally using 4 cores,
 you may submit your job like this::
 
-   $ sbatch -A lp_myproject -M genius -t 2:00:00 --ntasks=4 myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=genius --time=2:00:00 --ntasks=4 myjobscript.slurm
    # or
-   $ sbatch -A lp_myproject -M genius -t 2:00:00 --ntasks=1 --cpus-per-task=4 myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=genius --time=2:00:00 --ntasks=1 --cpus-per-task=4 myjobscript.slurm
 
 .. note::
 
@@ -122,17 +122,17 @@ different users.
 However, every user will have exclusive access to the number of GPUs requested. 
 If you want to use only 1 GPU of type P100 you can submit for example like this::
 
-   $ sbatch -A lp_my_project -M genius -N 1 -n 9 --gpus-per-node=1 -p gpu_p100 myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=9 --gpus-per-node=1 --partition=gpu_p100 myjobscript.slurm
   
 Note that in case of 1 GPU you have to request 9 cores. 
 In case you need more GPUs you have to multiply the 9 cores with the number of GPUs 
 requested, so in case of for example 3 GPUs you will have to specify this::
 
-   $ sbatch -A lp_my_project -M genius -N 1 -n 27 --gpus-per-node=3 -p gpu_p100 myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=27 --gpus-per-node=3 -p gpu_p100 myjobscript.slurm
 
 To specifically request V100 GPUs, you can submit for example like this::
 
-   $ sbatch -A lp_my_project -M genius -N 1 -n 4 --gpus-per-node=1 --mem-per-cpu=20000M -p gpu_v100 myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=4 --gpus-per-node=1 --mem-per-cpu=20000M --partition=gpu_v100 myjobscript.slurm
   
 For the V100 type of GPU, it is required that you request 4 cores for each GPU. 
 Also notice that these nodes offer a much larger amount of CPU memory.
@@ -146,7 +146,7 @@ The big memory nodes are located in the ``bigmem`` and ``bigmem_long`` partition
 In case of the big memory nodes it is also important to add your memory requirements, 
 for example::
 
-   $ sbatch -A lp_my_project -M genius -N 1 -n 36 --mem-per-cpu=20000M -p bigmem myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=36 --mem-per-cpu=20000M --partition=bigmem myjobscript.slurm
 
 
 .. _submit_genius_amd:
@@ -158,7 +158,7 @@ Besides specifying the partition, it is also important to note that the default 
 per core in this partition is 3800 MB, and each node contains 64 cores.
 For example, to request two full nodes::
 
-   $ sbatch -A lp_my_project -M genius -N 2 --ntasks-per-node=64 -p amd myjobscript.slurm 
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=2 --ntasks-per-node=64 --partition=amd myjobscript.slurm 
 
 
 .. _submit_genius_debug:
@@ -179,8 +179,8 @@ A few restrictions apply to a debug job:
 
 To run a debug job for 20 minutes on two CPU nodes, you would use::
 
-   $ sbatch -A lp_my_project -M genius -N 2 --ntasks-per-node=36 -p batch_debug -t 20:00 myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=2 --ntasks-per-node=36 --partition=batch_debug --time=20:00 myjobscript.slurm
 
 To run a debug job for 15 minutes on a GPU node, you would use::
 
-   $ sbatch -A lp_my_project -M genius -N 1 -n 9 --gpus-per-node=1 -p gpu_p100_debug -t 15:00 myjobscript.slurm
+   $ sbatch --account=lp_my_project --clusters=genius --nodes=1 --ntasks=9 --gpus-per-node=1 --partition=gpu_p100_debug --time=15:00 myjobscript.slurm

--- a/source/leuven/lecturer_s_procedure_to_request_student_accounts_ku_leuven_uhasselt.rst
+++ b/source/leuven/lecturer_s_procedure_to_request_student_accounts_ku_leuven_uhasselt.rst
@@ -54,7 +54,7 @@ several actions from the lecturer are required.
 
    ::
 
-      $ sbatch -A <project_name> --reservation=<reservation_name> jobscript.slurm
+      $ sbatch --account=<project_name> --reservation=<reservation_name> jobscript.slurm
 
    where ``project_name`` refers to the project created by the lecturer for
    the purpose of the course, and the ``<reservation_name>`` refers to an 

--- a/source/leuven/slurm_accounting.rst
+++ b/source/leuven/slurm_accounting.rst
@@ -42,9 +42,9 @@ If you for example have been granted introduction credits, the corresponding cre
 account will be named ``intro_vscxxxxx`` (with ``vscxxxxx`` referring to your VSC username).
 Submitting a batch job can then look as follows::
 
-   $ sbatch -A lp_my_project run-job.slurm
+   $ sbatch --account=lp_my_project run-job.slurm
    or
-   $ sbatch -A intro_vsc3xxxx run-job.slurm
+   $ sbatch --account=intro_vsc3xxxx run-job.slurm
 
 If the account to be charged, i.e., ``lp_my_project``, has insufficient credits for the 
 job, the user receives a warning at this point, and the job will not start until the account
@@ -60,12 +60,12 @@ of the cost of each individual job.
 The following command will provide an overview of all transactions for an account
 that the user has access to, as well as a summary of the credit usage at the top::
 
-     $ sam-statement -A lp_my_project
+     $ sam-statement --account=lp_my_project
 
 It is more convenient to filter this information for a specific period of time, 
 e.g.::
 
-   $ sam-statement -A lp_my_project -s 2023-01-01 -e 2023-01-31
+   $ sam-statement --account=lp_my_project --start=2023-01-01 --end=2023-01-31
 
 This will show the transactions on the account for the ``lp_my_project`` project for 
 the month January 2023.
@@ -74,7 +74,7 @@ If you are only interested in the overview of your past credit usage, and don't 
 the actual balance information, ``sam-list-usagerecords`` provides a much faster 
 alternative for a summarized statement::
 
-   $ sam-list-usagerecords -A lp_my_project -s 2023-01-01 -e 2023-01-31
+   $ sam-list-usagerecords --account=lp_my_project --start=2023-01-01 --end=2023-01-31
 
 .. note::
 
@@ -83,4 +83,4 @@ alternative for a summarized statement::
      Individual users can only see their own usage and not that of other users of 
      the same credit account.
      The latter is only available to users who have been given a Coordinator role.
-   - All ``sam``-commands provide help by running them with ``-h`` option
+   - All ``sam``-commands provide help by running them with ``-h|--help`` option

--- a/source/leuven/superdome_quick_start.rst
+++ b/source/leuven/superdome_quick_start.rst
@@ -27,17 +27,17 @@ Superdome jobs get access to a number of cores which is a multiple of 14.
 The allocation for the following job will hence consist of an entire socket
 (and its 14 cores)::
 
-  $ sbatch -M genius -p superdome -A myaccount --ntasks=1 myscript.slurm
+  $ sbatch --account=lp_my_project --clusters=genius --partition=superdome --ntasks=1 myscript.slurm
 
 By default, each task will be launched on a separate socket. The following
 job will therefore get two sockets (and so 28 cores in total)::
 
-  $ sbatch -M genius -p superdome -A myaccount --ntasks=2 myscript.slurm
+  $ sbatch --account=lp_my_project --clusters=genius --partition=superdome --ntasks=2 myscript.slurm
 
 If you want to get multiple Slurm tasks per socket you will need to use the
 ``--ntasks-per-socket`` option, for example::
 
-  $ sbatch -M genius -p superdome -A myaccount --ntasks=28 --ntasks-per-socket=14 myscript.slurm
+  $ sbatch --account=lp_my_project --clusters=genius --partition=superdome --ntasks=28 --ntasks-per-socket=14 myscript.slurm
 
 .. note::
 

--- a/source/leuven/superdome_quick_start.rst
+++ b/source/leuven/superdome_quick_start.rst
@@ -27,17 +27,20 @@ Superdome jobs get access to a number of cores which is a multiple of 14.
 The allocation for the following job will hence consist of an entire socket
 (and its 14 cores)::
 
-  $ sbatch --account=lp_my_project --clusters=genius --partition=superdome --ntasks=1 myscript.slurm
+  $ sbatch --account=lp_my_project --clusters=genius --partition=superdome \
+           --ntasks=1 myscript.slurm
 
 By default, each task will be launched on a separate socket. The following
 job will therefore get two sockets (and so 28 cores in total)::
 
-  $ sbatch --account=lp_my_project --clusters=genius --partition=superdome --ntasks=2 myscript.slurm
+  $ sbatch --account=lp_my_project --clusters=genius --partition=superdome \
+           --ntasks=2 myscript.slurm
 
 If you want to get multiple Slurm tasks per socket you will need to use the
 ``--ntasks-per-socket`` option, for example::
 
-  $ sbatch --account=lp_my_project --clusters=genius --partition=superdome --ntasks=28 --ntasks-per-socket=14 myscript.slurm
+  $ sbatch --account=lp_my_project --clusters=genius --partition=superdome \
+           --ntasks=28 --ntasks-per-socket=14 myscript.slurm
 
 .. note::
 

--- a/source/leuven/wice_advanced_guide.rst
+++ b/source/leuven/wice_advanced_guide.rst
@@ -106,7 +106,7 @@ Slurm such as:
 
     Our Slurm scheduler is aware of multiple clusters and ``wice`` is not the
     default one. As a consequence, any Slurm command (such as `scontrol`,
-    `squeue`, `sacct`) needs to be executed with the option ``--cluster=wice``
+    `squeue`, `sacct`) needs to be executed with the option ``--clusters=wice``
     (or ``-M wice`` in short) in order to get information for the wICE cluster.
 
 For convenience, we provide the ``slurm_jobinfo`` tool, which runs and parses

--- a/source/leuven/wice_advanced_guide.rst
+++ b/source/leuven/wice_advanced_guide.rst
@@ -198,7 +198,7 @@ An interactive job can be launched as follows:
 .. code-block:: shell
 
    srun --ntasks-per-node=9 --nodes=1 --gpus-per-node=1 --account=<YOUR_ACCOUNT> \
-        --cluster=wice --time=01:00:00 --partition=gpu --gpu_cmode=shared \
+        --clusters=wice --time=01:00:00 --partition=gpu --gpu_cmode=shared \
         --pty /bin/bash -l
 
 A few notes on this features:

--- a/source/leuven/wice_quick_start.rst
+++ b/source/leuven/wice_quick_start.rst
@@ -57,7 +57,7 @@ Submit to a compute node
 
 In these examples, the submission will be done from login nodes of the Genius cluster, 
 therefore you always need to explicitly specify the cluster you want to use.
-The relevant option for that is ``-M|--cluster`` which takes ``wice`` or ``genius`` as
+The relevant option for that is ``-M|--clusters`` which takes ``wice`` or ``genius`` as
 a valid value.
 
 To submit to a compute node you need to provide the required number of nodes and cores. 

--- a/source/leuven/wice_quick_start.rst
+++ b/source/leuven/wice_quick_start.rst
@@ -62,7 +62,7 @@ a valid value.
 To submit to a compute node you need to provide the required number of nodes and cores. 
 For example to request 2 nodes with each 72 cores for 2 hours you can submit like this::
 
-   $ sbatch --cluster=wice --nodes=2 --ntasks-per-node=72 --time=2:00:00  -A lp_myproject  myjobscript.slurm
+   $ sbatch --account=lp_myproject --cluster=wice --nodes=2 --ntasks-per-node=72 --time=2:00:00 myjobscript.slurm
    
 More information about accounting used on wice can be found on the :ref:`Leuven accounting <accounting_leuven>`
 page and on :ref:`KU Leuven credits <KU Leuven credits>`.
@@ -72,7 +72,7 @@ Submit a long job to a compute node
 
 To submit to a compute node a job longer than 3 days you need to submit specifically to the ``batch_long`` partition::
 
-   $ sbatch --cluster=wice --nodes=2 --ntasks-per-node=72 --time=6-16:00:00 --partition=batch_long -A lp_myproject  myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=wice --nodes=2 --ntasks-per-node=72 --time=6-16:00:00 --partition=batch_long myjobscript.slurm
 
 .. _submit to wice interactive node:
 
@@ -86,7 +86,7 @@ These nodes are intended for interactive use.
 Instead of submitting a job script, you open an interactive session on a compute node as 
 follows::
 
-   $ srun -n 1 -t 01:00:00 -A lp_myproject --partition=interactive --cluster=wice --pty bash -l
+   $ srun --account=lp_myproject --ntasks=1 --time=01:00:00 --partition=interactive --clusters=wice --pty bash -l
 
 If a GPU is necessary for the visualization process, it can be requested (max 1 GPU instance 
 and total of 8 cores for at most 16 hours). 
@@ -94,7 +94,7 @@ The available GPU is a single A100 which has been split in 7 GPU instances (one 
 will be allocated to your job). 
 Additionally, X11 forwarding should be enabled::
 
-   $ srun -N 1 -t 16:00:00 --ntasks-per-node=8 --gpus-per-node=1 -A lp_myproject -p interactive --cluster=wice --x11 --pty bash -l
+   $ srun --account=lp_myproject --nodes=1 --time=16:00:00 --ntasks-per-node=8 --gpus-per-node=1 --partition=interactive --clusters=wice --x11 --pty bash -l
 
 .. note::
 
@@ -122,7 +122,7 @@ The big memory nodes (2048GB of RAM) are also located in the ``bigmem`` partitio
 In case of the big memory nodes it is also important to add your memory requirements 
 (the maximum of memory per core that can be requested is 28000MB/core), for example::
 
-   $ sbatch --cluster=wice --time=01:00:00 --nodes=2 --ntasks-per-node=72 --partition=bigmem --mem-per-cpu=28000M --account=lp_myproject myjobscript.slurm
+   $ sbatch --account=lp_myproject --cluster=wice --time=01:00:00 --nodes=2 --ntasks-per-node=72 --partition=bigmem --mem-per-cpu=28000M myjobscript.slurm
 
 
 .. _submit to wice GPU node:
@@ -136,11 +136,11 @@ Similar to the other nodes, the GPU nodes can be shared by different jobs from d
 However every user will have exclusive access to the number of GPUs requested. 
 If you want to use only 1 GPU of type A100 you can submit for example like this::
 
-   $ sbatch --cluster=wice -A lp_myproject -N 1 --ntasks=18 --gpus-per-node=1 --partition=gpu myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=wice --nodes=1 --ntasks=18 --gpus-per-node=1 --partition=gpu myjobscript.slurm
   
 Note that in case of 1 GPU you have to request 18 cores. 
 In case you need more GPUs you have to multiply the 18 cores with the number of GPUs 
 requested, so in case of for example 3 GPUs you will have to specify this::
 
-   $ sbatch --cluster=wice -A lp_myproject -N 1 --ntasks=54 --gpus-per-node=3 --partition=gpu myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=wice --nodes=1 --ntasks=54 --gpus-per-node=3 --partition=gpu myjobscript.slurm
 

--- a/source/leuven/wice_quick_start.rst
+++ b/source/leuven/wice_quick_start.rst
@@ -34,7 +34,7 @@ A Slurm jobscript for wICE will typically look like this:
 ::
    
     #!/bin/bash -l
-    #SBATCH --cluster=wice
+    #SBATCH --clusters=wice
     #SBATCH --partition=...
     #SBATCH --time=...
     #SBATCH --nodes=...
@@ -46,7 +46,8 @@ A Slurm jobscript for wICE will typically look like this:
 
     ...
 
-For information about using and installing software on wICE, see the :ref:`advanced guide for wICE<wice_t2_leuven_advanced>`.
+For information about using and installing software on wICE, see the 
+:ref:`advanced guide for wICE<wice_t2_leuven_advanced>`.
 
 
 .. _submit to wice compute node:
@@ -62,7 +63,8 @@ a valid value.
 To submit to a compute node you need to provide the required number of nodes and cores. 
 For example to request 2 nodes with each 72 cores for 2 hours you can submit like this::
 
-   $ sbatch --account=lp_myproject --cluster=wice --nodes=2 --ntasks-per-node=72 --time=2:00:00 myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=wice --nodes=2 --ntasks-per-node=72 \
+            --time=2:00:00 myjobscript.slurm
    
 More information about accounting used on wice can be found on the :ref:`Leuven accounting <accounting_leuven>`
 page and on :ref:`KU Leuven credits <KU Leuven credits>`.
@@ -72,7 +74,8 @@ Submit a long job to a compute node
 
 To submit to a compute node a job longer than 3 days you need to submit specifically to the ``batch_long`` partition::
 
-   $ sbatch --account=lp_myproject --clusters=wice --nodes=2 --ntasks-per-node=72 --time=6-16:00:00 --partition=batch_long myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=wice --nodes=2 --ntasks-per-node=72 \
+            --time=6-16:00:00 --partition=batch_long myjobscript.slurm
 
 .. _submit to wice interactive node:
 
@@ -86,7 +89,8 @@ These nodes are intended for interactive use.
 Instead of submitting a job script, you open an interactive session on a compute node as 
 follows::
 
-   $ srun --account=lp_myproject --ntasks=1 --time=01:00:00 --partition=interactive --clusters=wice --pty bash -l
+   $ srun --account=lp_myproject --ntasks=1 --time=01:00:00 --partition=interactive \
+          --clusters=wice --pty bash -l
 
 If a GPU is necessary for the visualization process, it can be requested (max 1 GPU instance 
 and total of 8 cores for at most 16 hours). 
@@ -94,7 +98,8 @@ The available GPU is a single A100 which has been split in 7 GPU instances (one 
 will be allocated to your job). 
 Additionally, X11 forwarding should be enabled::
 
-   $ srun --account=lp_myproject --nodes=1 --time=16:00:00 --ntasks-per-node=8 --gpus-per-node=1 --partition=interactive --clusters=wice --x11 --pty bash -l
+   $ srun --account=lp_myproject --nodes=1 --time=16:00:00 --ntasks-per-node=8 \
+          --gpus-per-node=1 --partition=interactive --clusters=wice --x11 --pty bash -l
 
 .. note::
 
@@ -122,7 +127,8 @@ The big memory nodes (2048GB of RAM) are also located in the ``bigmem`` partitio
 In case of the big memory nodes it is also important to add your memory requirements 
 (the maximum of memory per core that can be requested is 28000MB/core), for example::
 
-   $ sbatch --account=lp_myproject --cluster=wice --time=01:00:00 --nodes=2 --ntasks-per-node=72 --partition=bigmem --mem-per-cpu=28000M myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=wice --time=01:00:00 --nodes=2 \
+            --ntasks-per-node=72 --partition=bigmem --mem-per-cpu=28000M myjobscript.slurm
 
 
 .. _submit to wice GPU node:
@@ -136,11 +142,13 @@ Similar to the other nodes, the GPU nodes can be shared by different jobs from d
 However every user will have exclusive access to the number of GPUs requested. 
 If you want to use only 1 GPU of type A100 you can submit for example like this::
 
-   $ sbatch --account=lp_myproject --clusters=wice --nodes=1 --ntasks=18 --gpus-per-node=1 --partition=gpu myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=wice --nodes=1 --ntasks=18 \
+            --gpus-per-node=1 --partition=gpu myjobscript.slurm
   
 Note that in case of 1 GPU you have to request 18 cores. 
 In case you need more GPUs you have to multiply the 18 cores with the number of GPUs 
 requested, so in case of for example 3 GPUs you will have to specify this::
 
-   $ sbatch --account=lp_myproject --clusters=wice --nodes=1 --ntasks=54 --gpus-per-node=3 --partition=gpu myjobscript.slurm
+   $ sbatch --account=lp_myproject --clusters=wice --nodes=1 --ntasks=54 \
+            --gpus-per-node=3 --partition=gpu myjobscript.slurm
 


### PR DESCRIPTION
This PR tries to bring a consistency on Slurm job submission arguments across all Leuven pages. Anywhere that the argument shorthand had been used (such as `-A`) are changed to the long-format (such as `--account=<account-name>`).