### PR TITLE
Removed outdated UAntwerpen tutorial texts.

### DIFF
--- a/source/vsc_tutorials.rst
+++ b/source/vsc_tutorials.rst
@@ -17,14 +17,6 @@ operating system from which you access the cluster:
 
 **Linux**
 
-**UAntwerpen**
-
-[`PDF <http://hpcugent.github.io/vsc_user_docs/pdf/intro-HPC-windows-antwerpen.pdf>`__]
-
-[`PDF <http://hpcugent.github.io/vsc_user_docs/pdf/intro-HPC-mac-antwerpen.pdf>`__]
-
-[`PDF <http://hpcugent.github.io/vsc_user_docs/pdf/intro-HPC-linux-antwerpen.pdf>`__]
-
 **VUB**
 
 [`PDF <http://hpcugent.github.io/vsc_user_docs/pdf/intro-HPC-windows-brussel.pdf>`__]


### PR DESCRIPTION
Removed the links to the UAntwerpen tutorial texts. Their content is outdated for our current setup.