### PR TITLE
Extend vsc tutorials description

### DIFF
--- a/source/vsc_tutorials.rst
+++ b/source/vsc_tutorials.rst
@@ -17,7 +17,8 @@ KULeuven/UHasselt
 The training material (slides and exercises) for the a variety of HPC-related trainings from
 the KULeuven/UHasselt site are organized via the 
 `official Github repository <https://github.com/hpcleuven>`__. 
-The beginners might consider following:
+New users without prior experience with Linux or the HPC might consider the following
+introductory tutorials:
 
 * `HPC Introduction <https://hpcleuven.github.io/HPC-intro/>`__
 * `Linux for HPC <https://hpcleuven.github.io/Linux-for-HPC/>`__

--- a/source/vsc_tutorials.rst
+++ b/source/vsc_tutorials.rst
@@ -14,7 +14,7 @@ to those training materials.
 KULeuven/UHasselt
 -----------------
 
-The training material (slides and exercises) for the a variety of HPC-related trainings from
+The training material (slides and exercises) for a variety of HPC-related trainings from
 the KULeuven/UHasselt site are organized via the 
 `official Github repository <https://github.com/hpcleuven>`__. 
 New users without prior experience with Linux or the HPC might consider the following

--- a/source/vsc_tutorials.rst
+++ b/source/vsc_tutorials.rst
@@ -5,14 +5,24 @@ VSC tutorials
 Site Tutorials
 ==============
 
-VSC sites carry out regular trainings about Linux and the VSC HPC systems. It is
-complementary to the information found in this user portal, the latter being
-the reference manual. Below you can find links to those training materials.
+VSC sites carry out regular trainings about Linux and the VSC HPC systems. 
+You may always find the updated list of `VSC trainings <https://www.vscentrum.be/vsctraining>`__ 
+via the VSC website. It is complementary to the information found in this 
+user portal, the latter being the reference manual. Below you can find links 
+to those training materials.
 
 KULeuven/UHasselt
 -----------------
 
+The training material (slides and exercises) for the a variety of HPC-related trainings from
+the KULeuven/UHasselt site are organized via the 
+`official Github repository <https://github.com/hpcleuven>`__. 
+The beginners might consider following:
+
 * `HPC Introduction <https://hpcleuven.github.io/HPC-intro/>`__
+* `Linux for HPC <https://hpcleuven.github.io/Linux-for-HPC/>`__
+* `Linux Scripting <https://hpcleuven.github.io/Linux-scripting/>`__
+* `Linux Tools <https://hpcleuven.github.io/Linux-tools/>`
 
 
 UAntwerpen

--- a/source/vsc_tutorials.rst
+++ b/source/vsc_tutorials.rst
@@ -23,7 +23,7 @@ introductory tutorials:
 * `HPC Introduction <https://hpcleuven.github.io/HPC-intro/>`__
 * `Linux for HPC <https://hpcleuven.github.io/Linux-for-HPC/>`__
 * `Linux Scripting <https://hpcleuven.github.io/Linux-scripting/>`__
-* `Linux Tools <https://hpcleuven.github.io/Linux-tools/>`
+* `Linux Tools <https://hpcleuven.github.io/Linux-tools/>`__
 
 
 UAntwerpen


### PR DESCRIPTION
This PR follows #365 . I noticed that the trainings offered by other HPC sites are thoroughly documented here https://docs.vscentrum.be/interesting_links.html#training-programs-in-other-centres. However, there was no single mention of our own official VSC training page on the docs. So, this PR:

- follows that of #365 
- tries to promote VSC trainings (but a single sentence may not be enough; so, feel free to propose any improvements here)
- describes that the KUL/UH trainings are spread over various github repositories (in contrast to those of other sites which are nicely organized under a single website)
- proposed changes are only for the KUL/UH site