### PR TITLE
rename sitemap file to vsc-docs-sitemap.xml

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -272,6 +272,7 @@ notfound_urls_prefix = ''
 
 # -- Sitemap Extension -------------------------------------------------------
 sitemap_url_scheme = "{link}"
+sitemap_filename = "vsc-docs-sitemap.xml"
 
 # -- Page redirects ----------------------------------------------------------
 redirects = {

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://docs.vscentrum.be/sitemap.xml
+Sitemap: https://docs.vscentrum.be/vsc-docs-sitemap.xml


### PR DESCRIPTION
Fixes (again) #366

Readthedocs generates its own `sitemap.xml` overwriting any custom one. Apparently, custom `sitemap.xml` is a paid feature.

So we will just use another filename for the sitemap. The name of the file does not really matter, crawlers will follow whatever is defined in `robots.txt`.