### PR TITLE
Remove ref to video (broken link) in generating_keys_with_putty.rst

### DIFF
--- a/source/access/generating_keys_with_putty.rst
+++ b/source/access/generating_keys_with_putty.rst
@@ -24,10 +24,7 @@ Create a public/private key pair
 
 To generate a public/private key pair, you can use the PuTTYgen key
 generator, which is available on the `PuTTY download site`_.
-Start it and follow the following steps. Alternatively, you can follow a
-`short video <https://hervsc.live.statik.be/assets/1189>`_
-explaining step-by-step the process of generating a new key pair and
-saving it in a format required by different VSC login nodes.
+Start it and follow the following steps. 
 
 #. In 'Parameters' (at the bottom of the window), choose 'RSA' and
    set the number of bits in the key to 4096:


### PR DESCRIPTION
The link for the short video doesn't exist anymore, could not find it anywhere else either.