### PR TITLE
 Collecting UA-specific Slurm info

### DIFF
--- a/source/antwerp/tier2_hardware.rst
+++ b/source/antwerp/tier2_hardware.rst
@@ -8,4 +8,5 @@ UAntwerp Tier-2 Infrastructure
    tier2_hardware/leibniz_hardware
    tier2_hardware/hopper_hardware
    tier2_hardware/uantwerp_storage
+   uantwerp_slurm_specifics
    uantwerp_software_specifics

--- a/source/antwerp/uantwerp_slurm_specifics.rst
+++ b/source/antwerp/uantwerp_slurm_specifics.rst
@@ -37,3 +37,11 @@ On UAntwerp clusters we ask to only use the ``-N/--nodes`` option to request
 the empty cores cannot be used by other jobs. We furthermore ask to abstain
 from the ``--nodes=<minimum number>-<maximum number>`` option without
 consulting us first and discussing why it would make sense for your job.
+
+
+.. _uantwerp_atools_slurm:
+
+Atools module
+-------------
+On UAntwerp clusters the most recent version of the `atools` package is
+available as the module ``atools/slurm``.

--- a/source/antwerp/uantwerp_slurm_specifics.rst
+++ b/source/antwerp/uantwerp_slurm_specifics.rst
@@ -26,3 +26,14 @@ When requesting memory, keep in mind that no swap space is available in
 case your application runs out of memory. Swapping is disabled because the nodes
 don't have drives suitable for the load caused by swapping and because swapping
 is extremely detrimental to performance.
+
+
+.. _uantwerp_requesting_nodes:
+
+Requesting nodes
+----------------
+On UAntwerp clusters we ask to only use the ``-N/--nodes`` option to request
+(and use) full nodes. This is because in the current Slurm configuration
+the empty cores cannot be used by other jobs. We furthermore ask to abstain
+from the ``--nodes=<minimum number>-<maximum number>`` option without
+consulting us first and discussing why it would make sense for your job.

--- a/source/antwerp/uantwerp_slurm_specifics.rst
+++ b/source/antwerp/uantwerp_slurm_specifics.rst
@@ -1,0 +1,28 @@
+.. _uantwerp_slurm_specifics:
+
+Site-specific Slurm info
+========================
+
+While the :ref:`Running jobs in Slurm <running jobs>` and :ref:`job advanced`
+pages provide basic and advanced information regarding Slurm, there are
+additional points to consider when when using Slurm on Tier-2 clusters hosted
+at UAntwerpen.
+
+
+.. _uantwerp_pbs_to_slurm:
+
+Converting from PBS to Slurm
+----------------------------
+Have a look at the :ref:`quick PBS-to-Slurm conversion tables <Slurm_convert_from_PBS>`
+if you need help converting your PBS job scripts to Slurm. See also
+:ref:`A list of important differences between Torque and Slurm <Slurm_PBS_differences>`.
+
+
+.. _uantwerp_requesting_memory:
+
+Requesting memory
+-----------------
+When requesting memory, keep in mind that no swap space is available in
+case your application runs out of memory. Swapping is disabled because the nodes
+don't have drives suitable for the load caused by swapping and because swapping
+is extremely detrimental to performance.

--- a/source/antwerp/uantwerp_software_specifics.rst
+++ b/source/antwerp/uantwerp_software_specifics.rst
@@ -3,25 +3,6 @@
 UAntwerp-specific software instructions
 =======================================
 
-Slurm Workload Manager
-----------------------
-
-Both Leibniz and Vaughan run Slurm Workload Manager as the resource manager and scheduler.
-The Slurm documentation is work-in-progress
-as we are still refining the setup.
-
-- An overview of Slurm concepts and commands:
-    - The :ref:`running jobs` page contains the 
-      minimum that we expect a user to know.
-    - The :ref:`job advanced` page contains
-      some more advanced commands and additional ways to request resources. Check those
-      if you feel the basic information is not enough.
-- You can also have a look at our 
-  :ref:`quick PBS-to-Slurm conversion tables <Slurm_convert_from_PBS>` which will
-  help you convert your PBS job scripts to Slurm.
-- :ref:`A list of important differences between Torque and Slurm <Slurm_PBS_differences>`
-
-
 Software installed on the UAntwerp clusters
 -------------------------------------------
 

--- a/source/jobs/job_advanced.rst
+++ b/source/jobs/job_advanced.rst
@@ -18,7 +18,7 @@ those options should always be used in combination with other options.
 In combination with ``--ntasks`` and ``--cpus-per-task``
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-In addition to specifying the number of tasks and CPUs per task for a job, it is also
+In addition to specifying the number of tasks and cores per task for a job, it is also
 possible to specify the number of nodes that should be used. This is very useful on clusters
 that may spread out your tasks over more nodes than the minimum needed, which can happen
 if you would run your job on clusters (or partitions) that allow multiple users per node
@@ -34,20 +34,17 @@ is the exact number of nodes that will be allocated.
 
 It is also possible to specify both a minimum and a maximum number of nodes
 using either ``--nodes=<minimum number>-<maximum number>`` or
-``-N <minimum number>-<maximum number>``. However, we ask you not to use this option
-without consulting us first and discussing why it would make sense for your job.
+``-N <minimum number>-<maximum number>``.
 
 Note that you should be very careful when specifying the number of nodes:
 
 * Requesting more nodes than really needed is very asocial behaviour as it will decrease
   the efficiency of cluster use and lengthen the waiting time for other users.
 * If you request less nodes than is required to accommodate the tasks (if also specifying
-  the number of tasks and of CPUs per task), your job will be refused by the system.
+  the number of tasks and of cores per task), your job will be refused by the system.
 * If you only request nodes and forget to further specify the number of tasks and
-  CPUs per task, you will get the default of 1 CPU per node.
+  cores per task, you will get the default of 1 core per node.
 
-**Never use this option on the clusters at UAntwerp except to request (and use) full
-nodes as in the current Slurm configuration the empty cores cannot be used by other jobs.**
 
 In combination with ``--ntasks-per-node`` and ``--cpus-per-task``
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -63,26 +60,24 @@ In this scenario, a user specifies:
   line or in the input file to specify the node configuration.
 * The number of tasks per node using ``--ntasks-per-node=<number of tasks per node>``.
   The default is one task per node.
-* The number of CPUs per task using ``--cpus-per-task=<CPUs per task>`` or
-  ``-c <CPUs per task>``. Failing to specify this value results in
-  getting one CPU per task.
+* The number of cores per task using ``--cpus-per-task=<cores per task>`` or
+  ``-c <cores per task>``. Failing to specify this value results in
+  getting one core per task.
 
 In this case also one should be very careful when specifying the parameters:
 
 * Not filling up the nodes optimally is very asocial behaviour as it will decrease
   the efficiency of the cluster use and lengthen the waiting time for others.
-* Requesting a number of tasks per node in combination with a number of CPUs per task
+* Requesting a number of tasks per node in combination with a number of cores per task
   that cannot be accommodated on the cluster, will lead to the job being refused by
   Slurm.
 
-**This option should only be used on the UAntwerp cluster if you can fill nodes completely
-or have a very good reason to leave some cores empty.**
 
 Minimizing distance on the network for faster communications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The nodes in a cluster are connected with each other through a number of switches that
-form a hierarchical network tree (also called a topology). On the UAntwerp clusters,
+form a hierarchical network tree (also called a topology). On typical VSC clusters,
 the topology is a variant of the tree. All nodes are connected to an edge switch and
 hence split up naturally in groups corresponding to the edge switch they are connected
 with. These edge switches are then connected through a number of top level switches
@@ -95,7 +90,7 @@ a higher latency. Slurm tries to minimize network contention by identifying the 
 level switch in the hierarchy that can satisfy a job's request and then allocates the
 requested resources, based on a best-fit algorithm and the currently available resources.
 This may result in an allocation with more than the optimum number of switches when the
-cluster is under a heavy load (as is usually the case on the UAntwerp clusters).
+cluster is under a heavy load.
 
 A user can request a maximum number of switches for a job using the ``--switches=<count>``
 option. Usually, one would specify ``--switches=1`` here to make sure the job runs on
@@ -163,8 +158,8 @@ The command
     sinfo -N -l
 
 will return a more node-oriented output. You'll see node groups, the partition they
-belong to, and the amount of CPUs, memory (in MB), and temporary disk space available
-on that node group. On Vaughan the output is rather boring as all nodes are identical.
+belong to, and the amount of cores, memory (in MB), and temporary disk space available
+on that node group.
 
 By specifying additional command line arguments it is possible to further customize the
 output format. See the `sinfo manual page <https://slurm.schedmd.com/sinfo.html>`_.
@@ -208,8 +203,10 @@ program ``omp_hello`` on the allocated resources:
 
 .. code:: bash
 
+   login$ # Build the environment (UAntwerp example)
    login$ module --force purge
    login$ module load calcua/2020a vsc-tutorial
+   login$ # Launch the program
    login$ srun omp_hello
    login$ exit
 
@@ -230,13 +227,15 @@ and then run the program with
 
 .. code:: bash
 
+   login$ # Build the environment (UAntwerp example)
    login$ module --force purge
    login$ module load calcua/2020a vsc-tutorial
+   login$ # Launch the program
    login$ srun mpi_omp_hello
    login$ exit
 
 Note that since we are using all allocated resources, we don't need to specify the number of tasks
-or virtual CPUs to ``srun``. It will take care of of properly distributing the job according to the
+or cores to ``srun``. It will take care of of properly distributing the job according to the
 options specified when calling ``salloc``.
 
 

--- a/source/jobs/job_management.rst
+++ b/source/jobs/job_management.rst
@@ -89,7 +89,7 @@ that have finished already. It allows you to see how much CPU time, wall time,
 memory, etc. were used by the application.
 
 By default, ``sacct`` shows the job ID, job name, partition name, account name,
-number of CPUs allocated to the job, the state of the job and the exit code
+number of cores allocated to the job, the state of the job and the exit code
 of completed jobs. Several options can be used to modify the format:
 
 * ``--brief`` or ``-b`` shows only the job ID, state and exit ode.

--- a/source/jobs/job_types.rst
+++ b/source/jobs/job_types.rst
@@ -6,7 +6,7 @@ Example job types
 Shared memory job
 -----------------
 
-A shared memory program consists of a single task. The number of CPUs you would
+A shared memory program consists of a single task. The number of cores you would
 request for the task corresponds to the number of computational threads
 you want to use for the application. Keep in mind that a single task cannot
 span multiple nodes in the cluster.
@@ -21,9 +21,9 @@ will read the number of threads from the input file and then set it using OpenMP
 But most OpenMP programs simply use the environment variable ``OMP_NUM_THREADS`` to
 determine the number of threads that should be used.
 
-The following job script is an
-example of this. It assumes there is a program ``omp`` in the current directory
-compiled with the intel/2020a toolchain. It will be run on 10 cores.
+The following job script provides an example. It assumes there is a program
+``omp_hello`` in the current directory compiled with the intel/2020a toolchain.
+It will be run on 10 cores.
 
 .. code:: bash
 
@@ -33,7 +33,7 @@ compiled with the intel/2020a toolchain. It will be run on 10 cores.
    #SBATCH --ntasks=1 --cpus-per-task=10 --mem=2g
    #SBATCH --time=05:00
 
-   # Build the environment
+   # Build the environment (UAntwerp example)
    module --force purge
    module load calcua/2020a
    module load vsc-tutorial
@@ -44,10 +44,10 @@ compiled with the intel/2020a toolchain. It will be run on 10 cores.
    # Run the program
    omp_hello
 
-In this example, ``omp_hello`` is a demo program contained in the ``vsc-tutorial``
-module that will simply print a message from each thread. the ``vsc-tutorial``
-module also loads the ``intel/2020a`` module as that compiler was used to compile
-the programs in the module.
+In this example, ``omp_hello`` is a demo program contained in the (UAntwerp)
+``vsc-tutorial`` module that will simply print a message from each thread. The
+``vsc-tutorial`` module also loads the ``intel/2020a`` module as that compiler
+was used to compile the programs in the module.
 
 When using Intel OpenMP, not setting the variable ``OMP_NUM_THREADS``
 works fine in most or even all cases as the runtime seems to recognize Slurm and pick up
@@ -82,8 +82,8 @@ on our cluster), it is also possible to use the
 Slurm ``srun`` command to start the MPI processes. This is the case
 for programs compiled with Intel MPI as the example below shows. The
 example assumes there is a MPI program called ``mpi_hello`` provided by the
-``vsc-tutorial`` module. The ``vsc-tutorial`` module will also load the
-``intel/2020a`` module for the libraries used by the compiler and the
+(UAntwerp) ``vsc-tutorial`` module. The ``vsc-tutorial`` module will also load
+the ``intel/2020a`` module for the libraries used by the compiler and the
 MPI library.
 
 .. code:: bash
@@ -94,7 +94,7 @@ MPI library.
    #SBATCH --ntasks=56 --cpus-per-task=1 --mem-per-cpu=512m
    #SBATCH --time=5:00
 
-   # Build the environment
+   # Build the environment (UAntwerp example)
    module --force purge
    module load calcua/2020a
    module load vsc-tutorial
@@ -145,6 +145,7 @@ per node.
    #SBATCH --time=5:00
    #SBATCH --job-name=hybrid-hello-test
 
+   # Build the environment (UAntwerp example)
    module --force purge
    module load calcua/supported
    module load vsc-tutorial
@@ -201,9 +202,7 @@ submitted using
 
 Within the VSC, the package ``atools`` was developed to ease management of job arrays
 and to start programs using parameter values stored in a CSV file that can be generated
-easily using a spreadsheet program. On the UAntwerp clusters, the most recent version of
-the package is available as the module ``atools/slurm``.
-For information on how to use atools, we refer to the
+easily using a spreadsheet program. For information on how to use atools, we refer to the
 `atools documentation on ReadTheDocs <https://atools.readthedocs.io/en/latest/>`_ and
 `course material from a course at KU Leuven <https://gjbex.github.io/worker-and-atools/>`_.
 Note however that the Worker package which is also mentioned in that course does not work
@@ -306,8 +305,10 @@ denoting the command prompt of the compute node):
 
 .. code:: bash
 
+   r0c00cn0$ # Build the environment (UAntwerp example)
    r0c00cn0$ module --force purge
    r0c00cn0$ module load calcua/2020a vsc-tutorial
+   r0c00cn0$ # Start the application
    r0c00cn0$ srun mpi_hello
    r0c00cn0$ exit
 


### PR DESCRIPTION
For this one I just
- [x] moved UA-specific parts about Slurm to a new `2.1.5. Site-specific Slurm info` page (so under `2.1. UAntwerp Tier-2 Infrastructure`), similar to how we will presumably structure things for KU Leuven (#386),
- [x] made it clearer that some example commands are connected to UA (in e.g. `jobs/job_types.rst`),
- [x] renamed 'CPU' to 'core' where appropriate.

There are for sure more things that can be improved in the Slurm info pages, but so this is one piece of it ;).

Closes #385