### PR TITLE
Add wICE extension hardware details

### DIFF
--- a/source/leuven/tier2_hardware/genius_hardware.rst
+++ b/source/leuven/tier2_hardware/genius_hardware.rst
@@ -19,21 +19,21 @@ Hardware details
   - 86 skylake nodes
 
     - 2 Xeon Gold 6140 CPUs\@2.3 GHz (Skylake), 18 cores each
-    - 192 GB RAM (:ref:`memory bandwidth and latency measurements <memory bandwidth and latency skylake tier2>`)
+    - 192 GiB RAM (:ref:`memory bandwidth and latency measurements <memory bandwidth and latency skylake tier2>`)
     - 200 GB SSD local disk
     - feature skylake
 
   - 144 cascadelake nodes
 
     - 2 Xeon Gold 6240 CPUs\@2.6 GHz (Cascadelake), 18 cores each
-    - 192 GB RAM (:ref:`memory bandwidth and latency measurements <memory bandwidth and latency cascadelake tier2>`)
+    - 192 GiB RAM (:ref:`memory bandwidth and latency measurements <memory bandwidth and latency cascadelake tier2>`)
     - 200 GB SSD local disk
     - feature cascadelake 
 
 - 10 big memory nodes
 
   - 2 Xeon Gold 6140 CPUs\@2.3 GHz (Skylake), 18 cores each
-  - 768 GB RAM
+  - 768 GiB RAM
   - 200 GB SSD local disk
   - partition ``bigmem``, specific Slurm :ref:`options <submit_genius_bigmem>` apply
 
@@ -42,23 +42,23 @@ Hardware details
   - 20 P100 nodes
 
     - 2 Xeon Gold 6140 CPUs\@2.3 GHz (Skylake), 18 cores each
-    - 192 GB RAM
-    - 4 NVIDIA P100 SXM2\@1.3 GHz, 16 GB GDDR, connected with NVLink
+    - 192 GiB RAM
+    - 4 NVIDIA P100 SXM2\@1.3 GHz, 16 GiB GDDR, connected with NVLink
     - 200 GB SSD local disk
     - partition ``gpu_p100``, specific Slurm :ref:`options <submit_genius_gpu>` apply
 
   - 2 V100 nodes
 
     - 2 Xeon Gold 6240 CPUs\@2.6 GHz (Cascadelake), 18 cores each
-    - 768 GB RAM
-    - 8 NVIDIA V100 SXM2\@1.5 GHz, 32 GB GDDR, connected with NVLink
+    - 768 GiB RAM
+    - 8 NVIDIA V100 SXM2\@1.5 GHz, 32 GiB GDDR, connected with NVLink
     - 200 GB SSD local disk
     - partition ``gpu_v100``, specific Slurm :ref:`options <submit_genius_gpu>` apply
 
 - 4 AMD nodes
 
   - 2 EPYC 7501 CPUs\@2.0 GHz, 32 cores each
-  - 256 GB RAM
+  - 256 GiB RAM
   - 200 GB SSD local disk
   - partition ``amd``, specific Slurm :ref:`options <submit_genius_amd>` apply
 

--- a/source/leuven/tier2_hardware/superdome_hardware.rst
+++ b/source/leuven/tier2_hardware/superdome_hardware.rst
@@ -12,7 +12,7 @@ Superdome consists of
 - 8 sockets with
 
     - Xeon Gold 6132 CPU\@2.6 GHz (Skylake), 14 cores each
-    - 750 GB RAM each
+    - 768 GiB RAM each
 
 - a 6 TB local node disk
 

--- a/source/leuven/tier2_hardware/wice_hardware.rst
+++ b/source/leuven/tier2_hardware/wice_hardware.rst
@@ -13,30 +13,30 @@ Hardware details
 - 172 thin nodes 
    
   - 2 Intel Xeon Platinum 8360Y CPUs\@2.4 GHz (Ice lake), 36 cores each
-  - 256 GB RAM 
+  - 256 GiB RAM
   - 960 GB SSD local disk
   - partitions ``batch/batch_long``, :ref:`submit options <submit to wice compute node>`
 
 - 5 big memory nodes
 
   - 2 Intel Xeon Platinum 8360Y CPUs\@2.4 GHz (Ice lake), 36 cores each
-  - 2048 GB RAM
+  - 2048 GiB RAM
   - 960 GB SSD local disk
   - partition ``bigmem``, :ref:`submit options <submit to wice big memory node>`
 
 - 4 GPU nodes, 16 GPU devices
 
   - 2 Intel Xeon Platinum 8360Y CPUs\@2.4 GHz (Ice lake), 36 cores each
-  - 512 GB RAM
-  - 4 NVIDIA A100 SXM4, 80 GB GDDR, connected with NVLink
+  - 512 GiB RAM
+  - 4 NVIDIA A100 SXM4, 80 GiB GDDR, connected with NVLink
   - 960 GB SSD local disk
   - partition ``gpu``, :ref:`submit options <submit to wice GPU node>`
 
 - 5 interactive nodes
 
   - 2 Intel Xeon Gold 8358 CPUs\@2.6 GHz (Ice lake), 32 cores each
-  - 512 GB RAM
-  - 1 NVIDIA A100, 80 GB GDDR 
+  - 512 GiB RAM
+  - 1 NVIDIA A100, 80 GiB GDDR
   - 960 GB SSD local disk
   - partition ``interactive``, :ref:`submit options <submit to wice interactive node>`
 
@@ -56,7 +56,7 @@ which will be made accessible during the spring of 2024:
   - 2 Intel Xeon Platinum 8468 CPUs (Sapphire Rapids),
     48 cores each :raw-html:`<br />`
     The base and max CPU frequencies are 2.1 GHz and 3.8 GHz, respectively.
-  - 256 GB RAM
+  - 256 GiB RAM
   - 960 GB SSD local disk
   - partitions ``batch_sapphirerapids/batch_sapphirerapids_long``
 
@@ -65,8 +65,8 @@ which will be made accessible during the spring of 2024:
   - 2 AMD EPYC 9334 CPUs (Genoa),
     32 cores each :raw-html:`<br />`
     The base and max CPU frequencies are 2.7 GHz and 3.9 GHz, respectively.
-  - 770 GB RAM
-  - 4 NVIDIA H100 SXM4, 80 GB HBM3, connected with NVLink
+  - 768 GiB RAM
+  - 4 NVIDIA H100 SXM4, 80 GiB HBM3, connected with NVLink
   - 960 GB SSD local disk
   - partition ``gpu_h100``
 
@@ -75,7 +75,7 @@ which will be made accessible during the spring of 2024:
   - 2 Intel Xeon Platinum 8360Y CPUs (Ice lake),
     36 cores each :raw-html:`<br />`
     The base and max CPU frequencies are 2.4 GHz and 3.5 GHz, respectively.
-  - 8192 GB RAM
+  - 8 TiB RAM
   - 960 GB SSD local disk
   - partition ``hugemem``
 

--- a/source/leuven/tier2_hardware/wice_hardware.rst
+++ b/source/leuven/tier2_hardware/wice_hardware.rst
@@ -44,3 +44,41 @@ The nodes are connected using an Infiniband HDR-100 network, the islands are ind
 
 .. figure:: wice_hardware/wice.png
    :alt: wICE hardware diagram
+
+
+Hardware details (extension)
+----------------------------
+We are currently installing and testing additional hardware for wICE,
+which will be made accessible during the spring of 2024:
+
+- 68 thin nodes
+
+  - 2 Intel Xeon Platinum 8468 CPUs (Sapphire Rapids),
+    48 cores each :raw-html:`<br />`
+    The base and max CPU frequencies are 2.1 GHz and 3.8 GHz, respectively.
+  - 256 GB RAM
+  - 960 GB SSD local disk
+  - partitions ``batch_sapphirerapids/batch_sapphirerapids_long``
+
+- 4 GPU nodes, 16 GPU devices
+
+  - 2 AMD EPYC 9334 CPUs (Genoa),
+    32 cores each :raw-html:`<br />`
+    The base and max CPU frequencies are 2.7 GHz and 3.9 GHz, respectively.
+  - 770 GB RAM
+  - 4 NVIDIA H100 SXM4, 80 GB HBM3, connected with NVLink
+  - 960 GB SSD local disk
+  - partition ``gpu_h100``
+
+- 1 huge memory node
+
+  - 2 Intel Xeon Platinum 8360Y CPUs (Ice lake),
+    36 cores each :raw-html:`<br />`
+    The base and max CPU frequencies are 2.4 GHz and 3.5 GHz, respectively.
+  - 8192 GB RAM
+  - 960 GB SSD local disk
+  - partition ``hugemem``
+
+The thin nodes and GPU nodes are all in the same Infiniband HDR-100 network
+island. These nodes are furthermore the first ones in the data center
+to be direct liquid cooled.

--- a/source/leuven/tier2_hardware/wice_hardware.rst
+++ b/source/leuven/tier2_hardware/wice_hardware.rst
@@ -79,6 +79,10 @@ which will be made accessible during the spring of 2024:
   - 960 GB SSD local disk
   - partition ``hugemem``
 
-The thin nodes and GPU nodes are all in the same Infiniband HDR-100 network
-island. These nodes are furthermore the first ones in the data center
+Only the thin nodes are interconnected with Infiniband HDR-100, with all nodes
+inside the same network island. The GPU nodes can only communicate over
+ethernet (no high-performance interconnect). All nodes are however connected
+to the Lustre parallel file system through an Infiniband HDR-100 network.
+
+The thin nodes and GPU nodes are furthermore the first ones in the data center
 to be direct liquid cooled.


### PR DESCRIPTION
This just adds the hardware details for the wICE extension, in a separate subsection.

(Once it gets opened for general usage we can put everything in the same list and update the source/leuven/tier2_hardware/wice_hardware/wice.png figure.)