### PR TITLE
Update Lirias virtual collection to KUL-HPC

### DIFF
--- a/source/how_do_i_acknowledge_the_vsc_in_publications.rst
+++ b/source/how_do_i_acknowledge_the_vsc_in_publications.rst
@@ -21,6 +21,6 @@ English version
   Foundation - Flanders (FWO) and the Flemish Government.
 
 |KUL| Moreover, if you are in the KU Leuven association, you are also
-requested to add the relevant papers to the virtual collection "High
-Performance Computing" in Lirias so that we can easily generate the
-publication lists with relevant publications.
+requested to add the relevant papers to the virtual collection "KUL-HPC"
+in Lirias so that we can easily generate the publication lists with relevant
+publications.


### PR DESCRIPTION
As noted in https://github.com/hpcleuven/VscDocumentation/issues/427, the name of the virtual collection in Lirias is called "KUL-HPC" and not “High Performance Computing" (see https://research.kuleuven.be/nl/associatienet/output/lirias/faqs_webnl/overzicht-virtuele-collecties-overview-virtual-collections). It looks like this has changed during the migration to Lirias 2.0, see https://admin.kuleuven.be/icts/english/services/wms/admin/staff/migration-to-lirias-2.0. 