### PR TITLE
Increase maximal walltime on KU Leuven debug partitions to 1 hour

### DIFF
--- a/source/leuven/genius_quick_start.rst
+++ b/source/leuven/genius_quick_start.rst
@@ -212,7 +212,7 @@ the ``batch_debug`` or ``gpu_p100_debug`` partition, respectively.
 A few restrictions apply to a debug job:
 
 - it can only use at most two nodes for CPU jobs, a single node for GPU jobs
-- its walltime is at most 30 minutes
+- its walltime is at most 1 hour
 - you can only have a single debug job in the queue at any time.
 
 To run a debug job for 20 minutes on two CPU nodes, you would use::

--- a/source/leuven/wice_quick_start.rst
+++ b/source/leuven/wice_quick_start.rst
@@ -167,4 +167,6 @@ e.g.::
             myjobscript.slurm
 
 The node in this partition is of the same type as those in the ``interactive``
-partition except that its A100 GPU is not divided into smaller instances.
+partition except that its A100 GPU is not divided into smaller instances. Note
+that you can only have a single ``gpu_a100_debug`` job in the queue at any
+time.

--- a/source/leuven/wice_quick_start.rst
+++ b/source/leuven/wice_quick_start.rst
@@ -159,7 +159,7 @@ per node) which you can select via the ``gpu_h100`` partition, e.g.::
             --nodes=1 --ntasks=16 --gpus-per-node=1 myjobscript.slurm
 
 For easier development and testing with a full GPU, also a ``gpu_a100_debug``
-partition is available which accepts jobs with walltimes up to 30 minutes,
+partition is available which accepts jobs with walltimes up to 1 hour,
 e.g.::
 
    $ sbatch --account=lp_myproject --clusters=wice --partition=gpu_a100_debug \


### PR DESCRIPTION
The maximal walltime on debug partitions was increased to 1 hour.