### PR TITLE
Adding memory-per-core info to hardware spec pages

### DIFF
--- a/source/leuven/tier2_hardware/genius_hardware.rst
+++ b/source/leuven/tier2_hardware/genius_hardware.rst
@@ -22,7 +22,7 @@ Hardware details
   - 192 GiB RAM (:ref:`memory bandwidth and latency measurements <memory bandwidth and latency cascadelake tier2>`)
   - default memory per core is 5000 MiB
   - 200 GB SSD local disk
-  - partition ``batch/batch_long``,
+  - partition ``batch|batch_long``,
     specific Slurm :ref:`options <submit_genius_batch>` apply
 
 - 12 interactive nodes
@@ -42,9 +42,9 @@ Hardware details
     18 cores each :raw-html:`<br />`
     (1 NUMA domain and 1 L3 cache per CPU)
   - 768 GiB RAM
-  - default memory per core is 21000 MiB
+  - default memory per core is 5000 MiB
   - 200 GB SSD local disk
-  - partition ``bigmem``, specific Slurm :ref:`options <submit_genius_bigmem>` apply
+  - partition ``bigmem|bigmem_long``, specific Slurm :ref:`options <submit_genius_bigmem>` apply
 
 - 22 GPGPU nodes, 96 GPU devices
 
@@ -57,7 +57,7 @@ Hardware details
     - default memory per core is 5000 MiB
     - 4 NVIDIA P100 SXM2\@1.3 GHz, 16 GiB GDDR, connected with NVLink
     - 200 GB SSD local disk
-    - partition ``gpu_p100``, specific Slurm :ref:`options <submit_genius_gpu>` apply
+    - partition ``gpu_p100|gpu_p100_long|gpu_p100_debug``, specific Slurm :ref:`options <submit_genius_gpu>` apply
 
   - 2 V100 nodes
 
@@ -68,7 +68,7 @@ Hardware details
     - default memory per core is 21000 MiB
     - 8 NVIDIA V100 SXM2\@1.5 GHz, 32 GiB GDDR, connected with NVLink
     - 200 GB SSD local disk
-    - partition ``gpu_v100``, specific Slurm :ref:`options <submit_genius_gpu>` apply
+    - partition ``gpu_v100|gpu_v100_long``, specific Slurm :ref:`options <submit_genius_gpu>` apply
 
 - 4 AMD nodes
 

--- a/source/leuven/tier2_hardware/genius_hardware.rst
+++ b/source/leuven/tier2_hardware/genius_hardware.rst
@@ -31,7 +31,7 @@ Hardware details
     18 cores each :raw-html:`<br />`
     (1 NUMA domain and 1 L3 cache per CPU)
   - 192 GiB RAM (:ref:`memory bandwidth and latency measurements <memory bandwidth and latency skylake tier2>`)
-  - default memory per core is 5000 MiB
+  - default memory per core is 2000 MiB
   - 200 GB SSD local disk
   - partition ``interactive``,
     specific Slurm :ref:`options <submit_genius_interactive>` apply
@@ -42,7 +42,7 @@ Hardware details
     18 cores each :raw-html:`<br />`
     (1 NUMA domain and 1 L3 cache per CPU)
   - 768 GiB RAM
-  - default memory per core is 5000 MiB
+  - default memory per core is 21000 MiB
   - 200 GB SSD local disk
   - partition ``bigmem|bigmem_long``, specific Slurm :ref:`options <submit_genius_bigmem>` apply
 

--- a/source/leuven/tier2_hardware/genius_hardware.rst
+++ b/source/leuven/tier2_hardware/genius_hardware.rst
@@ -20,6 +20,7 @@ Hardware details
     18 cores each :raw-html:`<br />`
     (1 NUMA domain and 1 L3 cache per CPU)
   - 192 GiB RAM (:ref:`memory bandwidth and latency measurements <memory bandwidth and latency cascadelake tier2>`)
+  - default memory per core is 5000 MB
   - 200 GB SSD local disk
   - partition ``batch/batch_long``,
     specific Slurm :ref:`options <submit_genius_batch>` apply
@@ -30,6 +31,7 @@ Hardware details
     18 cores each :raw-html:`<br />`
     (1 NUMA domain and 1 L3 cache per CPU)
   - 192 GiB RAM (:ref:`memory bandwidth and latency measurements <memory bandwidth and latency skylake tier2>`)
+  - default memory per core is 5000 MB
   - 200 GB SSD local disk
   - partition ``interactive``,
     specific Slurm :ref:`options <submit_genius_interactive>` apply
@@ -39,7 +41,8 @@ Hardware details
   - 2 Xeon Gold 6140 CPUs\@2.3 GHz (Skylake),
     18 cores each :raw-html:`<br />`
     (1 NUMA domain and 1 L3 cache per CPU)
-  - 768 GiB RAM
+  - 768 GB RAM
+  - default memory per core is 21000 MB
   - 200 GB SSD local disk
   - partition ``bigmem``, specific Slurm :ref:`options <submit_genius_bigmem>` apply
 
@@ -50,8 +53,9 @@ Hardware details
     - 2 Xeon Gold 6140 CPUs\@2.3 GHz (Skylake),
       18 cores each :raw-html:`<br />`
       (1 NUMA domain and 1 L3 cache per CPU)
-    - 192 GiB RAM
-    - 4 NVIDIA P100 SXM2\@1.3 GHz, 16 GiB GDDR, connected with NVLink
+    - 192 GB RAM
+    - default memory per core is 5000 MB
+    - 4 NVIDIA P100 SXM2\@1.3 GHz, 16 GB GDDR, connected with NVLink
     - 200 GB SSD local disk
     - partition ``gpu_p100``, specific Slurm :ref:`options <submit_genius_gpu>` apply
 
@@ -60,8 +64,9 @@ Hardware details
     - 2 Xeon Gold 6240 CPUs\@2.6 GHz (Cascadelake),
       18 cores each :raw-html:`<br />`
       (1 NUMA domain and 1 L3 cache per CPU)
-    - 768 GiB RAM
-    - 8 NVIDIA V100 SXM2\@1.5 GHz, 32 GiB GDDR, connected with NVLink
+    - 768 GB RAM
+    - default memory per core is 21000 MB
+    - 8 NVIDIA V100 SXM2\@1.5 GHz, 32 GB GDDR, connected with NVLink
     - 200 GB SSD local disk
     - partition ``gpu_v100``, specific Slurm :ref:`options <submit_genius_gpu>` apply
 
@@ -70,7 +75,8 @@ Hardware details
   - 2 EPYC 7501 CPUs\@2.0 GHz,
     32 cores each :raw-html:`<br />`
     (4 NUMA domains and 8 L3 caches per CPU)
-  - 256 GiB RAM
+  - 256 GB RAM
+  - default memory per core is 3800 MB
   - 200 GB SSD local disk
   - partition ``amd``, specific Slurm :ref:`options <submit_genius_amd>` apply
 

--- a/source/leuven/tier2_hardware/genius_hardware.rst
+++ b/source/leuven/tier2_hardware/genius_hardware.rst
@@ -20,7 +20,7 @@ Hardware details
     18 cores each :raw-html:`<br />`
     (1 NUMA domain and 1 L3 cache per CPU)
   - 192 GiB RAM (:ref:`memory bandwidth and latency measurements <memory bandwidth and latency cascadelake tier2>`)
-  - default memory per core is 5000 MB
+  - default memory per core is 5000 MiB
   - 200 GB SSD local disk
   - partition ``batch/batch_long``,
     specific Slurm :ref:`options <submit_genius_batch>` apply
@@ -31,7 +31,7 @@ Hardware details
     18 cores each :raw-html:`<br />`
     (1 NUMA domain and 1 L3 cache per CPU)
   - 192 GiB RAM (:ref:`memory bandwidth and latency measurements <memory bandwidth and latency skylake tier2>`)
-  - default memory per core is 5000 MB
+  - default memory per core is 5000 MiB
   - 200 GB SSD local disk
   - partition ``interactive``,
     specific Slurm :ref:`options <submit_genius_interactive>` apply
@@ -41,8 +41,8 @@ Hardware details
   - 2 Xeon Gold 6140 CPUs\@2.3 GHz (Skylake),
     18 cores each :raw-html:`<br />`
     (1 NUMA domain and 1 L3 cache per CPU)
-  - 768 GB RAM
-  - default memory per core is 21000 MB
+  - 768 GiB RAM
+  - default memory per core is 21000 MiB
   - 200 GB SSD local disk
   - partition ``bigmem``, specific Slurm :ref:`options <submit_genius_bigmem>` apply
 
@@ -53,9 +53,9 @@ Hardware details
     - 2 Xeon Gold 6140 CPUs\@2.3 GHz (Skylake),
       18 cores each :raw-html:`<br />`
       (1 NUMA domain and 1 L3 cache per CPU)
-    - 192 GB RAM
-    - default memory per core is 5000 MB
-    - 4 NVIDIA P100 SXM2\@1.3 GHz, 16 GB GDDR, connected with NVLink
+    - 192 GiB RAM
+    - default memory per core is 5000 MiB
+    - 4 NVIDIA P100 SXM2\@1.3 GHz, 16 GiB GDDR, connected with NVLink
     - 200 GB SSD local disk
     - partition ``gpu_p100``, specific Slurm :ref:`options <submit_genius_gpu>` apply
 
@@ -64,9 +64,9 @@ Hardware details
     - 2 Xeon Gold 6240 CPUs\@2.6 GHz (Cascadelake),
       18 cores each :raw-html:`<br />`
       (1 NUMA domain and 1 L3 cache per CPU)
-    - 768 GB RAM
-    - default memory per core is 21000 MB
-    - 8 NVIDIA V100 SXM2\@1.5 GHz, 32 GB GDDR, connected with NVLink
+    - 768 GiB RAM
+    - default memory per core is 21000 MiB
+    - 8 NVIDIA V100 SXM2\@1.5 GHz, 32 GiB GDDR, connected with NVLink
     - 200 GB SSD local disk
     - partition ``gpu_v100``, specific Slurm :ref:`options <submit_genius_gpu>` apply
 
@@ -75,8 +75,8 @@ Hardware details
   - 2 EPYC 7501 CPUs\@2.0 GHz,
     32 cores each :raw-html:`<br />`
     (4 NUMA domains and 8 L3 caches per CPU)
-  - 256 GB RAM
-  - default memory per core is 3800 MB
+  - 256 GiB RAM
+  - default memory per core is 3800 MiB
   - 200 GB SSD local disk
   - partition ``amd``, specific Slurm :ref:`options <submit_genius_amd>` apply
 

--- a/source/leuven/tier2_hardware/superdome_hardware.rst
+++ b/source/leuven/tier2_hardware/superdome_hardware.rst
@@ -14,6 +14,7 @@ Superdome consists of
     - Xeon Gold 6132 CPU\@2.6 GHz (Skylake), 14 cores each
     - 768 GiB RAM each
     - default memory per core is 53500 MiB
+    - partition ``superdome|superdome_long``
 
 - a 6 TB local node disk
 

--- a/source/leuven/tier2_hardware/superdome_hardware.rst
+++ b/source/leuven/tier2_hardware/superdome_hardware.rst
@@ -13,6 +13,7 @@ Superdome consists of
 
     - Xeon Gold 6132 CPU\@2.6 GHz (Skylake), 14 cores each
     - 768 GiB RAM each
+    - default memory per core is 53500 MiB
 
 - a 6 TB local node disk
 

--- a/source/leuven/tier2_hardware/wice_hardware.rst
+++ b/source/leuven/tier2_hardware/wice_hardware.rst
@@ -20,6 +20,7 @@ Hardware details
       36 cores each :raw-html:`<br />`
       (1 NUMA domain and 1 L3 cache per CPU)
     - 256 GiB RAM
+    - default memory per core is 3455 MiB
     - 960 GB SSD local disk
     - partitions ``batch/batch_long``,
       :ref:`submit options <submit to wice compute node>`
@@ -31,6 +32,7 @@ Hardware details
       (4 NUMA domains and 1 L3 cache per CPU) :raw-html:`<br />`
       The base and max CPU frequencies are 2.1 GHz and 3.8 GHz, respectively.
     - 256 GiB RAM
+    - default memory per core is 2500 MiB
     - 960 GB SSD local disk
     - partitions ``batch_sapphirerapids/batch_sapphirerapids_long``
       :ref:`submit options <submit to wice compute node>`
@@ -41,6 +43,7 @@ Hardware details
     36 cores each :raw-html:`<br />`
     (2 NUMA domains and 1 L3 cache per CPU)
   - 2048 GiB RAM
+  - default memory per core is 28000 MiB
   - 960 GB SSD local disk
   - partition ``bigmem``,
     :ref:`submit options <submit to wice big memory node>`
@@ -52,6 +55,7 @@ Hardware details
     (1 NUMA domain and 1 L3 cache per CPU) :raw-html:`<br />`
     The base and max CPU frequencies are 2.4 GHz and 3.5 GHz, respectively.
   - 8 TiB RAM
+  - default memory  per core is 111900 MiB
   - 960 GB SSD local disk
   - partition ``hugemem``,
     :ref:`submit options <submit to wice big memory node>`
@@ -64,6 +68,7 @@ Hardware details
       36 cores each :raw-html:`<br />`
       (2 NUMA domains and 1 L3 cache per CPU)
     - 512 GiB RAM
+    - default memory per core is 7000 MiB
     - 4 NVIDIA A100 SXM4, 80 GiB GDDR, connected with NVLink
     - 960 GB SSD local disk
     - partition ``gpu``,
@@ -76,6 +81,7 @@ Hardware details
       (4 NUMA domains and 4 L3 caches per CPU) :raw-html:`<br />`
       The base and max CPU frequencies are 2.7 GHz and 3.9 GHz, respectively.
     - 768 GiB RAM
+    - default memory per core is 11700 MiB
     - 4 NVIDIA H100 SXM5, 80 GiB HBM3, connected with NVLink
     - 960 GB SSD local disk
     - partition ``gpu_h100``,
@@ -87,6 +93,7 @@ Hardware details
     32 cores each :raw-html:`<br />`
     (2 NUMA domains and 1 L3 cache per CPU)
   - 512 GiB RAM
+  - default memory per core is 7500 MiB
   - 1 NVIDIA A100, 80 GiB GDDR
   - 960 GB SSD local disk
   - partitions ``interactive``,

--- a/source/leuven/tier2_hardware/wice_hardware.rst
+++ b/source/leuven/tier2_hardware/wice_hardware.rst
@@ -20,9 +20,9 @@ Hardware details
       36 cores each :raw-html:`<br />`
       (1 NUMA domain and 1 L3 cache per CPU)
     - 256 GiB RAM
-    - default memory per core is 3455 MiB
+    - default memory per core is 3400 MiB
     - 960 GB SSD local disk
-    - partitions ``batch/batch_long``,
+    - partitions ``batch|batch_long|batch_icelake|batch_icelake_long``,
       :ref:`submit options <submit to wice compute node>`
 
   - 68 Sapphire Rapids nodes
@@ -34,7 +34,7 @@ Hardware details
     - 256 GiB RAM
     - default memory per core is 2500 MiB
     - 960 GB SSD local disk
-    - partitions ``batch_sapphirerapids/batch_sapphirerapids_long``
+    - partitions ``batch_sapphirerapids|batch_sapphirerapids_long``
       :ref:`submit options <submit to wice compute node>`
 
 - 5 big memory nodes
@@ -71,7 +71,7 @@ Hardware details
     - default memory per core is 7000 MiB
     - 4 NVIDIA A100 SXM4, 80 GiB GDDR, connected with NVLink
     - 960 GB SSD local disk
-    - partition ``gpu``,
+    - partition ``gpu|gpu_a100``,
       :ref:`submit options <submit to wice GPU node>`
 
   - 4 nodes with 16 H100 GPUs in total
@@ -87,7 +87,20 @@ Hardware details
     - partition ``gpu_h100``,
       :ref:`submit options <submit to wice GPU node>`
 
-- 4 interactive nodes and 1 debug node
+- 4 interactive nodes
+
+  - 2 Intel Xeon Gold 8358 CPUs\@2.6 GHz (Ice lake),
+    32 cores each :raw-html:`<br />`
+    (2 NUMA domains and 1 L3 cache per CPU)
+  - 512 GiB RAM
+  - default memory per core is 2000 MiB
+  - 1 NVIDIA A100, 80 GiB GDDR
+  - 960 GB SSD local disk
+  - partitions ``interactive``,
+    :ref:`submit options <submit to wice interactive node>`
+    :raw-html:`<br />`
+
+- 1 debug node
 
   - 2 Intel Xeon Gold 8358 CPUs\@2.6 GHz (Ice lake),
     32 cores each :raw-html:`<br />`
@@ -96,10 +109,7 @@ Hardware details
   - default memory per core is 7500 MiB
   - 1 NVIDIA A100, 80 GiB GDDR
   - 960 GB SSD local disk
-  - partitions ``interactive``,
-    :ref:`submit options <submit to wice interactive node>`
-    :raw-html:`<br />`
-    and ``gpu_a100_debug``,
+  - partitions ``gpu_a100_debug``,
     :ref:`submit options <submit to wice GPU node>`
 
 All nodes of the same type are interconnected using an Infiniband HDR-100


### PR DESCRIPTION
In response to a request from user(s) in the user survey of UD2023, in this PR, the information about the default memory per core is added to the following hardware specification pages. 
- genius
- superdome
- wice

- [x] First, [this internal PR](https://gitea.icts.kuleuven.be/ceif-lnx/puppet-hpc-root/pulls/1604) has to be approved.