### PR TITLE
Refurbishing of Leuven & common module documentation pages

### DIFF
--- a/source/gent/setting_up_the_environment_using_lmod_at_the_hpc_ugent_clusters.rst
+++ b/source/gent/setting_up_the_environment_using_lmod_at_the_hpc_ugent_clusters.rst
@@ -205,8 +205,8 @@ To see how a module would change the environment, use ``module show`` or
 
    $ ml show matplotlib/1.5.1-intel-2016a-Python-2.7.11
    ----------------------------- /apps/gent/CO7/haswell-ib/modules/all -----------------------------
-   whatis(\"Description: matplotlib is a python 2D plotting library which produces publication quality figures in a variety of 
-   hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python 
+   whatis(\"Description: matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
+   hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
    and ipython shell, web application servers, and six graphical user interface toolkits. - Homepage: http://matplotlib.org \")
    conflict(\"matplotlib\")
    load(\"intel/2016a\")
@@ -437,7 +437,7 @@ modules tool you should be aware of:
 -  ``module purge`` does not unload the ``cluster`` module
 -  ``modulecmd`` is not available anymore (only relevant for EasyBuild)
 
-| 
+|
 | See below for more detailed information.
 
 
@@ -462,7 +462,7 @@ message like:
 ::
 
    $ module load Python/2.7.11-intel-2016a
-   $ module load Python/3.5.1-intel-2016a 
+   $ module load Python/3.5.1-intel-2016a
    Lmod has detected the following error:  Your site prevents the automatic swapping of modules with same name.
    You must explicitly unload the loaded version of \"Python\" before you can load the new one. Use swap (or an unload
    followed by a load) to do this:

--- a/source/jobs/running_jobs_torque.rst
+++ b/source/jobs/running_jobs_torque.rst
@@ -51,7 +51,7 @@ We discuss this script line by line.
 - Line 7 changes the working directory to the directory in which the job will
   be submitted (that will be the value of the ``$PBS_O_WORKDIR`` environment
   variable when the job runs).
-- Lines 9 and 10 set up the environment by :ref:`loading the appropriate modules 
+- Lines 9 and 10 set up the environment by :ref:`loading the appropriate modules
   <module system basics>`.
 - Line 12 performs the actual computation, i.e., running a Python script.
 
@@ -67,7 +67,7 @@ More information is available on:
 
 .. toctree::
    :maxdepth: 2
-   
+
    Job resources <specifying_resources>
    Job names, output files and notifications <specifying_output_files_and_notifications>
    Starting programs <starting_programs_in_a_job>
@@ -146,14 +146,14 @@ For instance, for the running example, the output file would be
    Queue Name : q1h
    Resource List : walltime=00:05:00,nodes=1:ppn=1,neednodes=1:ppn=1
    ===== end of prologue =======
-   
+
    hello world!
-   
+
    ===== start of epilogue =====
    Date : Mon Aug  5 14:50:29 CEST 2019
    Session ID : 21768
    Resources Used : cput=00:00:00,vmem=0kb,walltime=00:00:02,mem=0kb,energy_used=0
-   Allocated Nodes : r3c08cn1.leibniz 
+   Allocated Nodes : r3c08cn1.leibniz
    Job Exit Code : 0
    ===== end of epilogue =======
 

--- a/source/jobs/running_jobs_torque.rst
+++ b/source/jobs/running_jobs_torque.rst
@@ -51,8 +51,8 @@ We discuss this script line by line.
 - Line 7 changes the working directory to the directory in which the job will
   be submitted (that will be the value of the ``$PBS_O_WORKDIR`` environment
   variable when the job runs).
-- Lines 9 and 10 set up the environment by :ref:`loading the appropriate modules
-  <module system basics>`.
+- Lines 9 and 10 set up the environment by
+  :ref:`loading the appropriate modules <module_system_basics>`.
 - Line 12 performs the actual computation, i.e., running a Python script.
 
 Every job script has the same basic structure.
@@ -74,7 +74,7 @@ More information is available on:
 
 .. seealso::
 
-   Using the :ref:`module system <module system basics>`
+   Using the :ref:`module system <module_system_basics>`
 
 Submitting and monitoring a job
 -------------------------------

--- a/source/jobs/starting_programs_in_a_job.rst
+++ b/source/jobs/starting_programs_in_a_job.rst
@@ -46,7 +46,7 @@ Loading modules
 The next step consists of loading the appropriate modules. This is no
 different from loading the modules on the login nodes to prepare for
 your job or when running programs on interactive nodes, so we refer to
-the :ref:`modules system<module system basics>` page.
+the :ref:`module system <module_system_basics>` page.
 
 Useful Torque environment variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/leuven/leuven_module_system.rst
+++ b/source/leuven/leuven_module_system.rst
@@ -1,31 +1,10 @@
-.. _genius_2_rocky:
+.. _leuven_module_system:
 
-Migration of Genius to Rocky 8
-==============================
+The module system on Leuven clusters
+====================================
 
-The operating system on :ref:`Genius <genius hardware>` nodes was updated
-from CentOS 7 to Rocky 8, the same operating system
-running on :ref:`wICE <wice hardware>` nodes. This update is strictly
-necessary because CentOS 7 will be
-`discontinued <https://www.redhat.com/en/engage/migrate-from-centos-20230404>`__
-and this poses security concerns. We have tried to make the migration as
-transparent as possible for users, but still there are a few changes to take
-into account. The first important item is that the way you can search for and
-load modules has changed. This probably affects all users and you are urged
-to carefully read the section on :ref:`centrally installed modules <impact_on_central_software>`.
-The second item is that users that installed their own software (this includes
-conda environments), will need to reinstall the software for the new OS. More
-details are outlined :ref:`below <impact_on_user_installed_software>`. If you
-still encounter problems *after* reading this documentation page, you can
-contact the :ref:`support team <user support VSC>`.
-
-.. _impact_on_central_software:
-
-Searching and loading centrally installed modules
--------------------------------------------------
-
-Introduction
-~~~~~~~~~~~~
+This page offers additional information about the module system used on the
+HPC clusters hosted at KU Leuven.
 
 A lot of scientific software is centrally available on the VSC clusters. To
 avoid conflicts between different software packages, the installations are
@@ -34,35 +13,45 @@ is used). The executables, libraries, headers, ... of a certain module can only
 be used after that module has been loaded. By loading a certain set of modules,
 you can easily set up an environment that has precisely the software you need.
 
-When an HPC cluster is not completely homogeneous (for instance there are
+
+.. _module_hierarchy:
+
+Module organization
+~~~~~~~~~~~~~~~~~~~
+
+When a cluster is not completely homogeneous (for instance there are
 differences regarding architecture or operating system between nodes), it is
 important to use the appropriate modules in your jobs. Using a module that is
 not suited for the node on which the job is running, can give suboptimal
-performance, or even completely fail to work. This is why modules are
-organized in different *software stacks*, differentiated by the operating
-system, the architecture, and the toolchain version. The good news is that in
-general you do not need to worry too much about this, as in most cases the
-correct software stack will be made available in a job automatically thanks
-to the *cluster modules*, as explained in the :ref:`next section <cluster_module>`.
+performance, or even completely fail to work.
+
+This is why modules are organized in different *software stacks*,
+differentiated by the operating system, the architecture, and the toolchain
+version. The good news is that in general you do not need to worry too much
+about this, as in most cases the correct software stack will be made available
+in a job automatically thanks to the *cluster modules*, as explained in the
+:ref:`next section <cluster_module>`.
+
 If you are interested in more technical details, you can read the section on
 :ref:`manually modifying the modulepath <manually_modifying_modulepath>`,
 which is oriented towards advanced users.
+
 
 .. _cluster_module:
 
 The cluster module
 ~~~~~~~~~~~~~~~~~~
 
-One crucial point to understand, is that a module is *available* only if it is
-located inside a directory contained in the ``$MODULEPATH`` environment
-variable. The ``$MODULEPATH`` environment variable is a colon-separated list of
+Background: a given module will only be available if it is located inside a
+directory contained in the ``$MODULEPATH`` environment variable.
+This ``$MODULEPATH`` environment variable is a colon-separated list of
 directories, and you can list all modules located inside those directories
 with the ``module avail`` command. The different software stacks mentioned
 earlier are located in different directories (see the
 :ref:`next section <manually_modifying_modulepath>` for more details), so in
 order to make sure you are loading modules from the appropriate software stack,
-you need to make sure your ``$MODULEPATH`` variable contains the appropriate
-paths for the node where you want to use a module.
+the ``$MODULEPATH`` variable needs to contains the appropriate paths for the
+node where you want to use a module.
 
 Because working with the different directories containing different software
 stacks is cumbersome, we advise users to rely on the *cluster* module to set
@@ -73,12 +62,11 @@ available. The *cluster* module is always available and you can see which
 versions can be loaded by executing ``module avail cluster``.
 
 On the login nodes and inside a job environment, the correct version of the
-cluster module will be loaded automatically. This means that for these cases, you do
-not need to take any special action: the modules from the appropriate software
-stack will be the only ones available to you. As a result of this change, you
-do not need to do ``module use/unuse`` in your jobscripts. Such lines can be
-perfectly removed from your jobscript (unless you deal with an exceptional
-case).
+cluster module will be loaded automatically. This means that for these cases,
+you do not need to take any special action: the modules from the appropriate
+software stack will be the only ones available to you. There is hence no need
+for ``module use/unuse`` commands in your jobscripts (unless you deal with an
+exceptional case).
 
 .. note::
 
@@ -197,6 +185,7 @@ available. For more information about ``module spider``, have a look at the
    software inside a container, but this is only the best option in some
    specific cases.
 
+
 .. _manually_modifying_modulepath:
 
 Manually modifying the modulepath
@@ -232,29 +221,3 @@ To remove the entry again:
 
    module unuse /apps/leuven/rocky8/skylake/2018a/modules/all
 
-.. _impact_on_user_installed_software:
-
-Impact on user-installed software
----------------------------------
-If you have installed a software package yourself in your own account, and you
-did this on a Genius CentOS 7 node, it must be recompiled on Genius on a node
-with the new OS.
-
-Conda environments
-----------------------------
-The Conda environment you installed might need reinstallations. If you already
-have a Conda environment that works on wICE, it also should work on Genius
-after the migration. If you only have a Conda environment working on Genius,
-it is best to create a new Conda installation. If you used ``pip`` to install
-software inside your conda environment and ``pip`` has compiled the package from
-source, you certainly need to recreate your conda environment. In this case,
-it is recommended to recreate your environment for full compatibility with the
-new OS. Best practice is to choose a new installation folder with explicit
-mention of the new OS, e.g.::
-
-   ${VSC_DATA}/miniconda3-rocky8
-
-In order to install miniconda in a new directory you can ::
-
-   bash Miniconda3-latest-Linux-x86_64.sh -b -p ${VSC_DATA}/miniconda3-rocky8
-   export PATH="${VSC_DATA}/miniconda3-rocky8/bin:${PATH}

--- a/source/leuven/leuven_module_system.rst
+++ b/source/leuven/leuven_module_system.rst
@@ -76,9 +76,8 @@ exceptional case).
    load the correct cluster module or set your ``$MODULEPATH`` in another way.
    This is why we advise to not use ``module --force purge`` in your jobs,
    unless you are well aware of the consequences. Note that it is ok to
-   execute ``module purge``, since the cluster module is a
-   `sticky module <https://lmod.readthedocs.io/en/latest/240_sticky_modules.html>`__
-   , which means it is not unloaded with ``module purge``.
+   execute ``module purge``, since the cluster modules are
+   :ref:`sticky <module_purge>`.
 
 A common scenario is that you want to search through the installed modules for
 a software package you need, while you are on a login node. There are two ways

--- a/source/leuven/leuven_module_system.rst
+++ b/source/leuven/leuven_module_system.rst
@@ -213,3 +213,7 @@ To remove the entry again:
 
    module unuse /apps/leuven/rocky8/skylake/2018a/modules/all
 
+Keep in mind that also ``/apps/leuven/common/modules/all`` is part of your
+default ``$MODULEPATH``. This module collection is intended for packages which
+have no operating system or toolchain dependencies. Typical examples are
+packages which are distributed as precompiled binaries such as FLUENT.

--- a/source/leuven/leuven_module_system.rst
+++ b/source/leuven/leuven_module_system.rst
@@ -16,24 +16,24 @@ When a cluster is not completely homogeneous (for instance there are
 differences regarding architecture or operating system between nodes), it is
 important to use the appropriate modules in your jobs. Using a module that is
 not suited for the node on which the job is running, can give suboptimal
-performance, or even completely fail to work.
+performance or may even completely fail to work.
 
 This is why modules are organized in different *software stacks*,
 differentiated by the operating system, the architecture, and the toolchain
 version. The good news is that in general you do not need to worry too much
 about this, as in most cases the correct software stack will be made available
-in a job automatically thanks to the *cluster modules*, as explained in the
-:ref:`next section <cluster_module>`.
+in a job automatically thanks to the *cluster* modules, as explained in the
+:ref:`next section <cluster_modules>`.
 
 If you are interested in more technical details, you can read the section on
 :ref:`manually modifying the modulepath <manually_modifying_modulepath>`,
 which is oriented towards advanced users.
 
 
-.. _cluster_module:
+.. _cluster_modules:
 
-The cluster module
-~~~~~~~~~~~~~~~~~~
+The cluster modules
+~~~~~~~~~~~~~~~~~~~
 
 Background: a given module will only be available if it is located inside a
 directory contained in the ``$MODULEPATH`` environment variable.
@@ -43,15 +43,15 @@ with the ``module avail`` command. The different software stacks mentioned
 earlier are located in different directories (see the
 :ref:`next section <manually_modifying_modulepath>` for more details), so in
 order to make sure you are loading modules from the appropriate software stack,
-the ``$MODULEPATH`` variable needs to contains the appropriate paths for the
+the ``$MODULEPATH`` variable needs to contain the appropriate paths for the
 node where you want to use a module.
 
 Because working with the different directories containing different software
-stacks is cumbersome, we advise users to rely on the *cluster* module to set
-the ``$MODULEPATH`` variable. The *cluster* module can be handled identically
+stacks is cumbersome, we advise users to rely on the cluster module to set
+the ``$MODULEPATH`` variable. The cluster module can be handled identically
 as other modules, but instead of making executables or libraries available,
 its only purpose is to set up your environment to make the correct modules
-available. The *cluster* module is always available and you can see which
+available. The cluster module is always available and you can see which
 versions can be loaded by executing ``module avail cluster``.
 
 On the login nodes and inside a job environment, the correct version of the
@@ -94,7 +94,7 @@ run jobs on the wICE batch partition, the commmand is:
    $ module load cluster/wice/batch
 
 Note that the previously loaded cluster module will be automatically unloaded:
-at most 1 cluster module can be loaded at a time. Now you can search for
+at most one cluster module can be loaded at a time. Now you can search for
 modules containing ``CP2K`` by executing (the search is not case sensitive):
 
 .. code-block:: shell

--- a/source/leuven/leuven_module_system.rst
+++ b/source/leuven/leuven_module_system.rst
@@ -6,13 +6,6 @@ The module system on Leuven clusters
 This page offers additional information about the module system used on the
 HPC clusters hosted at KU Leuven.
 
-A lot of scientific software is centrally available on the VSC clusters. To
-avoid conflicts between different software packages, the installations are
-offered as modules (specifically, the `Lmod system <https://lmod.readthedocs.io/en/latest/>`__
-is used). The executables, libraries, headers, ... of a certain module can only
-be used after that module has been loaded. By loading a certain set of modules,
-you can easily set up an environment that has precisely the software you need.
-
 
 .. _module_hierarchy:
 

--- a/source/leuven/services/openondemand.rst
+++ b/source/leuven/services/openondemand.rst
@@ -261,7 +261,7 @@ from within a Linux terminal.
 This is different than the shell you get in the "Clusters - Login Server Shell Access" menu,
 which directs you towards one of the login nodes.
 
-Currently, the :ref:`cluster modules <cluster_module>` are not automatically loaded when your session starts.
+Currently, the :ref:`cluster modules <cluster_modules>` are not automatically loaded when your session starts.
 In order to use modules, one needs to explicitly load the cluster module that adheres to the choice of
 cluster and partition for his or her job.
 For instance, if your job starts on wICE interactive partition, one needs to execute the following command::

--- a/source/leuven/slurm_specifics.rst
+++ b/source/leuven/slurm_specifics.rst
@@ -28,7 +28,7 @@ Job shell
 For batch jobs we strongly recommend to use ``#!/bin/bash -l`` as the shebang
 at the top of your jobscript. The ``-l`` option (hyphen lowercase L) is needed
 to make sure that your ``~/.bashrc`` settings get applied and the appropriate
-:ref:`cluster module <cluster_module>` gets loaded at the start of the job.
+:ref:`cluster module <cluster_modules>` gets loaded at the start of the job.
 This is not strictly needed for interactive jobs: ``srun ... --pty bash``
 and ``srun ... --pty bash -l`` will give essentially identical environments.
 

--- a/source/leuven/tier2_genius.rst
+++ b/source/leuven/tier2_genius.rst
@@ -8,4 +8,3 @@ Tier-2 Genius
 
    tier2_hardware/genius_hardware
    genius_quick_start
-   genius_2_rocky

--- a/source/leuven/wice_advanced_guide.rst
+++ b/source/leuven/wice_advanced_guide.rst
@@ -82,7 +82,7 @@ partitions on the :ref:`genius hardware` and :ref:`wice hardware` pages.
 
 Many dependencies you might need are centrally installed. The modules
 that are optimized for wICE are available when the appropriate
-:ref:`cluster module <cluster_module>` is loaded. In most cases this will
+:ref:`cluster module <cluster_modules>` is loaded. In most cases this will
 happen automatically, but in case of problems it is a good idea to double check
 the ``$MODULEPATH`` environment variable; it should contain paths that look as
 starting with ``/apps/leuven/rocky8/${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX}``

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -19,7 +19,7 @@ equivalent ``ml``. To get a list of all available module commands, type:
 Available modules
 ~~~~~~~~~~~~~~~~~
 
-To view a list of available software packages, use the command
+To view the list of all available software packages, use the command
 ``module av``. The output will look similar to this:
 
 ::
@@ -39,6 +39,9 @@ To view a list of available software packages, use the command
    ---------------- /apps/leuven/rocky8/icelake/2022b/modules/all -----------------
    ATK/2.38.0-GCCcore-12.2.0                               (D)
    ...
+
+As such lists tend to be rather long, it is common to use more specific queries
+(see :ref:`Searching for modules <module_search>` below).
 
 
 Module names
@@ -66,6 +69,8 @@ When different modules exist for the same package, for example because it has
 been compiled with two different toolchains, please consider trying out the
 different modules so as to choose the one that performs best for your workloads.
 
+
+.. _module_search:
 
 Searching for modules
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -206,22 +206,23 @@ checking the list of currently loaded modules is always a good idea,
 just to make sure...
 
 
+.. _module_purge:
+
 Purging modules
 ~~~~~~~~~~~~~~~
 
-In order to unload all modules at once, and hence be sure to start with
-a clean slate, use:
+In order to unload all modules at once and start with a clean slate, use:
 
 ::
 
    $ module purge
 
-.. note::
-
-   It is a good habit to use this command in jobscripts, prior to loading
-   the modules specifically needed by applications in that job script. This
-   ensures that no version conflicts occur if the user loads module using
-   his ``.bashrc`` file.
+This will not unload so-called `sticky modules
+<https://lmod.readthedocs.io/en/latest/240_sticky_modules.html>`__, which
+are special modules that do not normally need to be unloaded (for example
+because they define the appropriate module paths and possibly other environment
+variables). If really needed, sticky modules can be unloaded with
+``module --force purge``.
 
 
 Getting help

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -184,9 +184,9 @@ can for example be combined as follows:
 .. warning::
 
    Do *not* load modules in your ``.bashrc``, ``.bash_profile`` or ``.profile``,
-   you *will* shoot yourself in the foot at some point.  Consider using
-   :ref:`module collections <collections of modules>` ``restore`` as a command
-   line alternative (so *not* in the shell initialization files either!).
+   you *will* shoot yourself in the foot at some point. If you want to avoid
+   typing the same module load commands over and over, we instead recommend to
+   define aliases or functions in your ``.bashrc``.
 
 
 Conflicting modules
@@ -282,49 +282,45 @@ variables). If really needed, sticky modules can be unloaded with
 Collections of modules
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Although it is convenient to set up your working environment by loading
-modules in your ``.bashrc`` or ``.profile`` file, this is error prone and
-you will end up shooting yourself in the foot at some point.
+It is also possible to bundle different modules together as a collection:
 
-The module system provides an alternative approach that lets you set up
-an environment with a single command, offering a viable alternative to
-polluting your ``.bashrc``.
-
-Define an environment
-
-   #. Be sure to start with a clean environment
+   #. Be sure to start with a clean environment:
       ::
 
          $ module purge
 
-   #. Load the modules you want in your environment, e.g.,
+   #. Load the modules you want in your collection, e.g.,
       ::
 
          $ module load matplotlib/3.7.2-gfbf-2023a
          $ module load MATLAB/2023b
 
-   #. save your environment, e.g., as ``data_analysis``
+   #. Save your collection, e.g., as ``data_analysis``
       ::
 
-          $ module save data_analysis
+         $ module save data_analysis
 
-Use an environment
+   #. At a later point, you can load the module collection via:
+      ::
 
-   ::
+         $ module restore data_analysis
 
-      $ module restore data_analysis
+   #. To list all your collections:
+      ::
 
-List all your environments
+         $ module savelist
 
-   ::
+   #. To remove the collection:
+      ::
 
-      $ module savelist
+         $ rm ~/.lmod.d/data_analysis
 
-Remove an environment
 
-   ::
+.. warning::
 
-      $ rm ~/.lmod.d/data_analysis
+   Be aware that module collections stop working when one of the
+   modules in the collection is reinstalled. In such cases the
+   collection needs to be removed and then redefined.
 
 
 .. _specialized software stacks:

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -195,7 +195,8 @@ Conflicting modules
 It is important to note that only modules that are compatible with
 each other should be loaded together. The loaded modules should all
 be associated with either the same toolchain or compatible (sub)toolchains
-(see also https://docs.easybuild.io/common-toolchains/#toolchains_diagram).
+(see also https://docs.easybuild.io/common-toolchains/#toolchains_diagram)
+or be ``system`` modules.
 
 For example, once you have loaded a module that uses the ``foss/2023a``
 toolchain, all other modules that you load next should have been installed

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -9,7 +9,11 @@ software applications.
 
 All VSC sites use a Lua based implementation called `Lmod`_. Interacting
 with the module system happens via the ``module`` command  or its shorter
-equivalent ``ml``.
+equivalent ``ml``. To get a list of all available module commands, type:
+
+::
+
+   $ module help
 
 
 Available modules
@@ -261,16 +265,6 @@ are special modules that do not normally need to be unloaded (for example
 because they define the appropriate module paths and possibly other environment
 variables). If really needed, sticky modules can be unloaded with
 ``module --force purge``.
-
-
-Getting help
-~~~~~~~~~~~~
-
-To get a list of all available module commands, type:
-
-::
-
-   $ module help
 
 
 .. _collections of modules:

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -59,8 +59,8 @@ versions of the :ref:`toolchains <toolchains>` based on the Intel and GNU
 compilers respectively. Certain modules may not belong to a particular toolchain.
 
 
-Searching modules
-~~~~~~~~~~~~~~~~~
+Searching for modules
+~~~~~~~~~~~~~~~~~~~~~
 
 Often, when looking for some specific software, you will want to filter
 the list of available modules, since it tends to be rather large. The
@@ -83,7 +83,8 @@ For more comprehensive searches, you can use ``module spider``, e.g.,
 Info on modules
 ~~~~~~~~~~~~~~~
 
-The ``spider`` sub-command can also be used to provide information on on modules, e.g.,
+The ``spider`` sub-command can also be used to provide information on a specific
+module, e.g.
 
 ::
 
@@ -109,8 +110,9 @@ The ``spider`` sub-command can also be used to provide information on on modules
 
 
 More technical information can be obtained using the ``show`` sub-command.
-It will show which other modules will be loaded and what environment paths
-will be set, e.g.:
+It will show which other modules will get loaded and in which ways various
+environment variables (``PATH``, ``LD_LIBRARY_PATH``, ...) will be modified,
+e.g.:
 
 ::
 
@@ -169,9 +171,9 @@ each other should be loaded together. The loaded modules should all
 be associated with either the same toolchain or compatible (sub)toolchains
 (see also https://docs.easybuild.io/common-toolchains/#toolchains_diagram).
 
-For example, once you have loaded one or more modules that use the
-``foss/2023a`` toolchain, all other modules that you load should have been
-installed with the same toolchain or with compatible (sub)toolchains such as
+For example, once you have loaded a module that uses the ``foss/2023a``
+toolchain, all other modules that you load next should have been installed
+with the same toolchain or with compatible (sub)toolchains such as
 ``GCC/12.3.0`` or ``GCCcore/12.3.0``.
 
 Additionally, two versions of the same software packages can not be loaded
@@ -212,8 +214,8 @@ dependencies of the explicitly loaded ``CP2K`` and ``GROMACS`` installations
 Unloading modules
 ~~~~~~~~~~~~~~~~~
 
-To unload a module, one can use the ``module unload`` command. It works
-consistently with the ``load`` command, and reverses the latter's
+To unload a specific module, use the ``module unload`` command.
+It works consistently with the ``load`` command, and reverses the latter's
 effect. One can however unload automatically loaded modules manually, to
 debug some problem.
 
@@ -224,7 +226,7 @@ debug some problem.
 Notice that the version was not specified: the module system is
 sufficiently clever to figure out what the user intends. However,
 checking the list of currently loaded modules is always a good idea,
-just to make sure...
+just to make sure.
 
 
 .. _module_purge:

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -228,10 +228,7 @@ dependencies of the explicitly loaded ``CP2K`` and ``GROMACS`` installations
 Unloading modules
 ~~~~~~~~~~~~~~~~~
 
-To unload a specific module, use the ``module unload`` command.
-It works consistently with the ``load`` command, and reverses the latter's
-effect. One can however unload automatically loaded modules manually, to
-debug some problem.
+To unload a specific module, use the ``module unload`` command, e.g.:
 
 ::
 
@@ -241,6 +238,10 @@ Notice that the version was not specified: the module system is
 sufficiently clever to figure out what the user intends. However,
 checking the list of currently loaded modules is always a good idea,
 just to make sure.
+
+Keep in mind that ``module unload`` only unloads the chosen module.
+It will not unload other modules which were automatically loaded
+as dependencies of the chosen module.
 
 
 .. _module_purge:

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -21,18 +21,20 @@ To view a list of available software packages, use the command
 ::
 
    $ module av
-   ----- /apps/leuven/skylake/2018a/modules/all ------
-   Autoconf/2.69-GCC-4.8.2
-   Autoconf/2.69-intel-2018a
-   Automake/1.14-GCC-4.8.2
-   Automake/1.14-intel-2018a
-   BEAST/2.1.2
+   ---------------- /apps/leuven/rocky8/icelake/2022b/modules/all -----------------
+   ATK/2.38.0-GCCcore-12.2.0                   (D)
+   Armadillo/11.4.3-foss-2022b
+   Autoconf/2.71-GCCcore-12.2.0
+   Automake/1.16.5-GCCcore-12.2.0
    ...
-   pyTables/2.4.0-intel-2018a-Python-2.7.6
-   timedrun/1.0.1
-   worker/1.4.2-foss-2018a
-   zlib/1.2.8-foss-2018a
-   zlib/1.2.8-intel-2018a
+   ---------------- /apps/leuven/rocky8/icelake/2021a/modules/all -----------------
+   ABAQUS/2023-hotfix-2306
+   ANTLR/2.7.7-GCCcore-10.3.0-Java-11
+   ASE/3.22.0-intel-2021a
+   ...
+   zlib/1.2.11
+   zlib/1.2.12
+   zstd/1.4.9-GCCcore-10.3.0
 
 
 Module names

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -161,6 +161,27 @@ can for example be combined as follows:
    line alternative (so *not* in the shell initialization files either!).
 
 
+Conflicting modules
+~~~~~~~~~~~~~~~~~~~
+
+It is important to note that only modules that are compatible with
+each other should be loaded together. The loaded modules should all
+be associated with either the same toolchain or compatible (sub)toolchains
+(see also https://docs.easybuild.io/common-toolchains/#toolchains_diagram).
+
+For example, once you have loaded one or more modules that use the
+``foss/2023a`` toolchain, all other modules that you load should have been
+installed with the same toolchain or with compatible (sub)toolchains such as
+``GCC/12.3.0`` or ``GCCcore/12.3.0``.
+
+Additionally, two versions of the same software packages can not be loaded
+together. If you e.g. loaded a ``Python/3.11.3-GCCcore-12.3.0`` module, then
+also loading another ``Python`` module (either directly or as a dependency of
+another module) will cause ``Python/3.11.3-GCCcore-12.3.0`` to be unloaded and
+replaced by the new module (the same will happen to the modules which both
+``Python`` modules load as dependencies).
+
+
 List loaded modules
 ~~~~~~~~~~~~~~~~~~~
 

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -63,7 +63,12 @@ For e.g. ``GROMACS/2023.3-foss-2023a-PLUMED-2.9.0``, we have
 
 Toolchains such as ``intel-2023a`` or ``foss-2023a`` refer to the 2023a
 versions of the :ref:`toolchains <toolchains>` based on the Intel and GNU
-compilers respectively. Certain modules may not belong to a particular toolchain.
+compilers respectively. Modules that do not belong to a particular toolchain
+are called ``system`` modules. For those modules, the module anatomy is simply
+
+::
+
+   <package>/<version>[-<extra>]
 
 When different modules exist for the same package, for example because it has
 been compiled with two different toolchains, please consider trying out the

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -67,21 +67,29 @@ Searching for modules
 ~~~~~~~~~~~~~~~~~~~~~
 
 Often, when looking for some specific software, you will want to filter
-the list of available modules, since it tends to be rather large. The
-module command writes its output to standard error, rather than standard
-output, which is somewhat confusing when using pipes to filter. The
-following command would show only the modules that have the string
-'python' in their name, regardless of the case.
+the list of available modules, since it tends to be rather large.
+For a (case-insensitive) search for modules containing the word ``python``,
+you can either try
 
 ::
 
-   $ module av |& grep -i python
+   $ module av python
 
-For more comprehensive searches, you can use ``module spider``, e.g.,
+or, for a more comprehensive search
 
 ::
 
    $ module spider python
+
+
+To restrict the search to modules where the package name ends with ``python``,
+add a trailing slash (e.g. ``module av python/``).
+
+.. note:
+
+   The module command writes its output to standard error, rather than standard
+   output. If you want to use pipes for filtering, consider using ``2>&1``
+   or ``|&`` (e.g. ``module av |& grep -i python``).
 
 
 Info on modules

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -1,47 +1,16 @@
-Software stack
-==============
+.. _module_system_basics:
 
-Software installation and maintenance on HPC infrastructure such as the
-VSC clusters poses a number of challenges not encountered on a
-workstation or a departmental cluster. For many libraries and programs,
-multiple versions have to installed and maintained as some users require
-specific versions of those. In turn, those libraries or executables sometimes
-rely on specific versions of other libraries, further complicating the
-matter.
+Module system basics
+====================
 
-The way Linux finds the right executable for a command, and a program
-loads the right version of a library or a plug-in, is through so-called
-environment variables. These can, e.g., be set in your shell
-configuration files (e.g., ``.bashrc``), but this requires a certain
-level of expertise. Moreover, getting those variables right is tricky
-and requires knowledge of where all files are on the cluster. Having to
-manage all this by hand is clearly not an option.
+Many software packages are installed as modules. These packages range from
+compilers, interpreters and mathematical libraries to the actual scientific
+software applications.
 
-We deal with this on the VSC clusters in the following way. First, we've
-defined the concept of a :ref:`toolchain <toolchains>`. They consist of
-a set of compilers, MPI library and
-basic libraries that work together well with each other, and then a
-number of applications and other libraries compiled with that set of
-tools and thus often dependent on those. We use tool chains based on the
-Intel and GNU compilers, and refresh them twice a year, leading to
-version numbers like 2014a, 2014b or 2015a for the first and second
-refresh of a given year. Some tools are installed outside a toolchain,
-e.g., additional versions requested by a small group of users for
-specific experiments, or tools that only depend on basic system
-libraries. Second, we use the module system to manage the environment
-variables and all dependencies and possible conflicts between various
-programs and libraries, and that is what this page focuses on.
+All VSC sites use a Lua based implementation called `Lmod`_. Interacting
+with the module system happens via the ``module`` command  or its shorter
+equivalent ``ml``.
 
-
-.. _module system basics:
-
-Using the module system
------------------------
-
-Many software packages are installed as modules. These packages include
-compilers, interpreters, mathematical software such as Matlab and SAS,
-as well as other applications and libraries. This is managed with the
-``module`` command.
 
 Available modules
 ~~~~~~~~~~~~~~~~~
@@ -343,3 +312,4 @@ leibniz cluster, one should first enter
    ::
 
       $ module load leibniz/2019a-experimental
+

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -58,6 +58,10 @@ Toolchains such as ``intel-2023a`` or ``foss-2023a`` refer to the 2023a
 versions of the :ref:`toolchains <toolchains>` based on the Intel and GNU
 compilers respectively. Certain modules may not belong to a particular toolchain.
 
+When different modules exist for the same package, for example because it has
+been compiled with two different toolchains, please consider trying out the
+different modules so as to choose the one that performs best for your workloads.
+
 
 Searching for modules
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -186,7 +186,9 @@ be associated with either the same toolchain or compatible (sub)toolchains
 For example, once you have loaded a module that uses the ``foss/2023a``
 toolchain, all other modules that you load next should have been installed
 with the same toolchain or with compatible (sub)toolchains such as
-``GCC/12.3.0`` or ``GCCcore/12.3.0``.
+``GCCcore/12.3.0``, ``GCC/12.3.0`` and ``gompi/2023a``. Subtoolchains
+compatible with e.g. ``intel/2023a`` include ``GCCcore/12.3.0``,
+``intel-compilers/2023.1.0`` and ``iimpi/2023a``.
 
 Additionally, two versions of the same software packages can not be loaded
 together. If you e.g. loaded a ``Python/3.11.3-GCCcore-12.3.0`` module, then

--- a/source/software/module_system_basics.rst
+++ b/source/software/module_system_basics.rst
@@ -21,20 +21,20 @@ To view a list of available software packages, use the command
 ::
 
    $ module av
+
+   ---------------- /apps/leuven/rocky8/icelake/2023a/modules/all -----------------
+   ATK/2.38.0-GCCcore-12.3.0                               (D)
+   Armadillo/12.6.2-foss-2023a                             (D)
+   Bison/3.8.2                                             (D)
+   ...
+   CP2K/2023.1-foss-2023a                                  (D)
+   CP2K/2023.1-intel-2023a
+   ...
+   zlib/1.2.13                                             (D)
+
    ---------------- /apps/leuven/rocky8/icelake/2022b/modules/all -----------------
-   ATK/2.38.0-GCCcore-12.2.0                   (D)
-   Armadillo/11.4.3-foss-2022b
-   Autoconf/2.71-GCCcore-12.2.0
-   Automake/1.16.5-GCCcore-12.2.0
+   ATK/2.38.0-GCCcore-12.2.0                               (D)
    ...
-   ---------------- /apps/leuven/rocky8/icelake/2021a/modules/all -----------------
-   ABAQUS/2023-hotfix-2306
-   ANTLR/2.7.7-GCCcore-10.3.0-Java-11
-   ASE/3.22.0-intel-2021a
-   ...
-   zlib/1.2.11
-   zlib/1.2.12
-   zstd/1.4.9-GCCcore-10.3.0
 
 
 Module names
@@ -46,21 +46,18 @@ In general, the anatomy of a module name is
 
    <package>/<version>-<toolchain>[-<extra>]
 
-For example  for ``Boost/1.66.0-intel-2018a-Python-3.6.4``, we
-have
+For e.g. ``GROMACS/2023.3-foss-2023a-PLUMED-2.9.0``, we have
 
-- ``<package>``: Boost, the name of the library,
-- ``<version>``: 1.66.0, the version of the Boost library,
-- ``<toolchain>``: intel-2018a, the toolchain Boost was built with, and
-- ``<extra>``: ``Python-3.6.4``, the version of Python this Boost version
-  can inter-operate with.
+- ``<package>``: GROMACS, the name of the software package,
+- ``<version>``: 2023.3, the GROMACS Version,
+- ``<toolchain>``: foss-2023a, the toolchain GROMACS was built with, and
+- ``<extra>``: ``PLUMED-2.9.0``, the version of PLUMED this GROMACS installation
+  can inter-operate with and will load as a dependency.
 
-Some packages in the list above include ``intel-2014a`` or ``foss-2014a`` in their name.
-These are packages installed with the 2014a versions of the :ref:`toolchains <toolchains>`
-based on the Intel and GNU compilers respectively. The other packages do
-not belong to a particular toolchain. The name of the packages also
-includes a version number (right after the /) and sometimes other
-packages they need.
+Toolchains such as ``intel-2023a`` or ``foss-2023a`` refer to the 2023a
+versions of the :ref:`toolchains <toolchains>` based on the Intel and GNU
+compilers respectively. Certain modules may not belong to a particular toolchain.
+
 
 Searching modules
 ~~~~~~~~~~~~~~~~~
@@ -90,68 +87,71 @@ The ``spider`` sub-command can also be used to provide information on on modules
 
 ::
 
-   $ module spider Python/2.7.14-foss-2018a
+   $ module spider Python/3.11.3-GCCcore-12.3.0
 
-   ---------------------------------------------
-     Python: Python/2.7.14-foss-2018a
-   -------------------------------------------
-       Description:
-           Python is a programming language that lets you work more
-           quickly and integrate your systems more effectively.
+   ----------------------------------------------------------------------------
+   Python: Python/3.11.3-GCCcore-12.3.0
+   ----------------------------------------------------------------------------
+    Description:
+      Python is a programming language that lets you work more quickly and
+      integrate your systems more effectively.
+
+      ...
+
+      More information
+      ================
+       - Homepage: https://python.org/
+
+      Included extensions
+      ===================
+      flit_core-3.9.0, packaging-23.1, pip-23.1.2, setuptools-67.7.2,
+      setuptools_scm-7.1.0, tomli-2.0.1, typing_extensions-4.6.3, wheel-0.40.0
 
 
-       This module can be loaded directly: module load Python/2.7.14-foss-2018a
-
-More technical information can be obtained using the ``show`` sub-command, e.g.,
+More technical information can be obtained using the ``show`` sub-command.
+It will show which other modules will be loaded and what environment paths
+will be set, e.g.:
 
 ::
 
-   $ module show Python/2.7.14-foss-2018a
+   $ module show Python/3.11.3-GCCcore-12.3.0
 
 
 Loading modules
 ~~~~~~~~~~~~~~~
 
-A module is loaded using the command ``module load`` with the name of
-the package, e.g., with the above list of modules,
+A module is loaded using the ``module load`` command, e.g.:
 
 ::
 
-   $ module load BEAST
+   $ module load CP2K
 
-will load the ``BEAST/2.1.2`` package.
+will load the default ``CP2K`` module (``CP2K/2023.1-foss-2023a`` in this
+example).
 
-For some packages, e.g., ``zlib`` in the above list, multiple versions
-are installed; the ``module load`` command will automatically choose the
-lexicographically last, which is typically, but not always, the most
-recent version. In the above example,
-
-::
-
-    $ module load zlib
-
-will load the module ``zlib/1.2.8-intel-2014a``. This may not be the
-module that you want if you're using the GNU compilers. In that case,
-the user should specify a particular version, e.g.,
+If multiple versions are installed; the ``module load`` command will
+automatically choose the default version, which is typically, but not always,
+the most recent version. If, in this example, you would prefer to use same
+version of CP2K but built with the ``intel-2023a`` toolchain, you would need
+to specify:
 
 ::
 
-   $ module load zlib/1.2.8-foss-2014a
+   $ module load CP2K/2023.1-intel-2023a
 
 .. note::
 
-   Loading modules with explicit versions is considered best practice.  It ensures
+   Loading modules with explicit versions is considered as best practice. It ensures
    that your scripts will use the expected version of the software, regardless of
-   newly installed software.  Failing to do this may jeopardize the reproducibility
+   newly installed software. Failing to do this may jeopardize the reproducibility
    of your results!
 
-Modules need not be loaded one by one; the two 'load' commands
-can be combined as follows::
+Modules need not be loaded one by one; two ``load`` sub-commands
+can for example be combined as follows:
 
-   $ module load  BEAST/2.1.2  zlib/1.2.8-foss-2014a
+::
 
-This will load the two modules and, automatically, the respective
-toolchains with just one command.
+   $ module load CP2K/2023.1-foss-2023a GROMACS/2023.3-foss-2023a-PLUMED-2.9.0
 
 .. warning::
 
@@ -165,39 +165,27 @@ List loaded modules
 ~~~~~~~~~~~~~~~~~~~
 
 Obviously, the user needs to keep track of the modules that are
-currently loaded. After executing the above two load commands, the list
-of loaded modules will be very similar to:
+currently loaded. After executing the above load command, the list
+of loaded modules will look similar to:
 
 ::
 
    $ module list
    Currently Loaded Modulefiles:
-     1) /thinking/2014a
-     2) Java/1.7.0_51
-     3) icc/2013.5.192
-     4) ifort/2013.5.192
-     5) impi/4.1.3.045
-     6) imkl/11.1.1.106
-     7) intel/2014a
-     8) beagle-lib/20140304-intel-2014a
-     9) BEAST/2.1.2
-    10) GCC/4.8.2
-    11) OpenMPI/1.6.5-GCC-4.8.2
-    12) gompi/2014a
-    13) OpenBLAS/0.2.8-gompi-2014a-LAPACK-3.5.0
-    14) FFTW/3.3.3-gompi-2014a
-    15) ScaLAPACK/2.0.2-gompi-2014a-OpenBLAS-0.2.8-LAPACK-3.5.0
-    16) foss/2014a
-    17) zlib/1.2.8-foss-2014a
+     1) cluster/wice/batch
+     2) GCCcore/10.3.0
+     ...
+     16) OpenMPI/4.1.1-GCC-10.3.0
+     17) OpenBLAS/0.3.15-GCC-10.3.0
+     ...
+     46) PLUMED/2.9.0-foss-2023a
+     47) CP2K/2023.1-foss-2023a
+     48) GROMACS/2023.3-foss-2023a-PLUMED-2.9.0
 
-It is important to note at this point that, e.g., ``icc/2013.5.192`` is
-also listed, although it was not loaded explicitly by the user. This is
-because ``BEAST/2.1.2`` depends on it, and the system administrator
-specified that the ``intel`` toolchain module that contains this
-compiler should be loaded whenever the ``BEAST`` module is loaded. There
-are advantages and disadvantages to this, so be aware of automatically
-loaded modules whenever things go wrong: they may have something to do
-with it!
+Note that this does not just show the two requested modules, but also all
+the modules that got loaded automatically in order to satisfy (runtime)
+dependencies of the explicitly loaded ``CP2K`` and ``GROMACS`` installations
+(``PLUMED``, ``OpenMPI``, ``OpenBLAS``, etcetera).
 
 
 Unloading modules
@@ -210,7 +198,7 @@ debug some problem.
 
 ::
 
-   $ module unload BEAST
+   $ module unload CP2K
 
 Notice that the version was not specified: the module system is
 sufficiently clever to figure out what the user intends. However,
@@ -230,7 +218,7 @@ a clean slate, use:
 
 .. note::
 
-   It is a good habit to use this command in PBS scripts, prior to loading
+   It is a good habit to use this command in jobscripts, prior to loading
    the modules specifically needed by applications in that job script. This
    ensures that no version conflicts occur if the user loads module using
    his ``.bashrc`` file.
@@ -269,8 +257,8 @@ Define an environment
    #. Load the modules you want in your environment, e.g.,
       ::
 
-         $ module load matplotlib/2.1.2-intel-2018a-Python-3.6.4
-         $ module load matlab/R2019a
+         $ module load matplotlib/3.7.2-gfbf-2023a
+         $ module load MATLAB/2023b
 
    #. save your environment, e.g., as ``data_analysis``
       ::

--- a/source/software/software_stack.rst
+++ b/source/software/software_stack.rst
@@ -120,15 +120,15 @@ The ``spider`` sub-command can also be used to provide information on on modules
 ::
 
    $ module spider Python/2.7.14-foss-2018a
-   
+
    ---------------------------------------------
      Python: Python/2.7.14-foss-2018a
    -------------------------------------------
        Description:
            Python is a programming language that lets you work more
-           quickly and integrate your systems more effectively. 
-   
-   
+           quickly and integrate your systems more effectively.
+
+
        This module can be loaded directly: module load Python/2.7.14-foss-2018a
 
 More technical information can be obtained using the ``show`` sub-command, e.g.,
@@ -292,36 +292,36 @@ Define an environment
 
    #. Be sure to start with a clean environment
       ::
-   
+
          $ module purge
-   
+
    #. Load the modules you want in your environment, e.g.,
       ::
-   
+
          $ module load matplotlib/2.1.2-intel-2018a-Python-3.6.4
          $ module load matlab/R2019a
-   
+
    #. save your environment, e.g., as ``data_analysis``
       ::
-     
+
           $ module save data_analysis
 
 Use an environment
 
    ::
-   
+
       $ module restore data_analysis
 
 List all your environments
 
    ::
-   
+
       $ module savelist
 
 Remove an environment
 
    ::
-   
+
       $ rm ~/.lmod.d/data_analysis
 
 
@@ -336,8 +336,8 @@ overwhelming. Therefore the administrators may have chosen to only show
 the most relevant packages by default, and not show, e.g., packages that
 aim at a different cluster, a particular node type or a less complete
 toolchain. Those additional packages can then be enabled by loading
-another module first. E.g., to get access to the modules in 
-the (at the time of writing) incomplete 2019a toolchain on UAntwerpen's 
+another module first. E.g., to get access to the modules in
+the (at the time of writing) incomplete 2019a toolchain on UAntwerpen's
 leibniz cluster, one should first enter
 
    ::

--- a/source/software/using_software.rst
+++ b/source/software/using_software.rst
@@ -1,9 +1,24 @@
 Using software
 ==============
 
-The scientific software stack on the VSC clusters is mainly exposed via
-:ref:`modules <module_system_basics>`. :ref:`Toolchains <toolchains>` are
-an important concept in this context.
+A lot of scientific software is centrally available on the VSC clusters. To
+avoid conflicts between different software packages, the installations are
+offered as :ref:`modules <module_system_basics>`. The executables, libraries,
+headers, ... of a certain module can only be used after that module has been
+loaded. By loading a certain set of modules, you can easily set up an
+environment that has precisely the software you need.
+
+:ref:`Toolchains <toolchains>` are an important concept in this context.
+A toolchain consists of a set of compilers, MPI library and
+basic libraries that work together well with each other, and then a
+number of applications and other libraries compiled with that set of
+tools and thus often dependent on those. We use toolchains based on the
+Intel and GNU compilers, and refresh them twice a year, leading to
+version numbers like 2014a, 2014b or 2015a for the first and second
+refresh of a given year. Some tools are installed outside a toolchain,
+e.g., additional versions requested by a small group of users for
+specific experiments, or tools that only depend on basic system
+libraries.
 
 For basic information on the module system and more site-specific information,
 please consult the following pages:
@@ -14,41 +29,6 @@ please consult the following pages:
    module_system_basics
    ../gent/setting_up_the_environment_using_lmod_at_the_hpc_ugent_clusters
    ../leuven/leuven_module_system
-
-
-Background
-----------
-
-Software installation and maintenance on HPC infrastructure such as the
-VSC clusters poses a number of challenges not encountered on a
-workstation or a departmental cluster. For many libraries and programs,
-multiple versions have to installed and maintained as some users require
-specific versions of those. In turn, those libraries or executables sometimes
-rely on specific versions of other libraries, further complicating the
-matter.
-
-The way Linux finds the right executable for a command, and a program
-loads the right version of a library or a plug-in, is through so-called
-environment variables. These can, e.g., be set in your shell
-configuration files (e.g., ``.bashrc``), but this requires a certain
-level of expertise. Moreover, getting those variables right is tricky
-and requires knowledge of where all files are on the cluster. Having to
-manage all this by hand is clearly not an option.
-
-We deal with this on the VSC clusters in the following way. First, we've
-defined the concept of a :ref:`toolchain <toolchains>`. They consist of
-a set of compilers, MPI library and
-basic libraries that work together well with each other, and then a
-number of applications and other libraries compiled with that set of
-tools and thus often dependent on those. We use tool chains based on the
-Intel and GNU compilers, and refresh them twice a year, leading to
-version numbers like 2014a, 2014b or 2015a for the first and second
-refresh of a given year. Some tools are installed outside a toolchain,
-e.g., additional versions requested by a small group of users for
-specific experiments, or tools that only depend on basic system
-libraries. Second, we use :ref:`modules <module_system_basics>` to manage the
-environment and all dependencies and possible conflicts
-between various programs and libraries.
 
 
 Packages with additional documentation

--- a/source/software/using_software.rst
+++ b/source/software/using_software.rst
@@ -34,7 +34,7 @@ adjustments and don't always show all packages. Be sure to check out
 
    .. toctree::
       :maxdepth: 2
-   
+
       ../gent/setting_up_the_environment_using_lmod_at_the_hpc_ugent_clusters
 
 Packages with additional documentation

--- a/source/software/using_software.rst
+++ b/source/software/using_software.rst
@@ -13,6 +13,7 @@ please consult the following pages:
 
    module_system_basics
    ../gent/setting_up_the_environment_using_lmod_at_the_hpc_ugent_clusters
+   ../leuven/leuven_module_system
 
 
 Background

--- a/source/software/using_software.rst
+++ b/source/software/using_software.rst
@@ -13,7 +13,7 @@ A toolchain consists of a set of compilers, MPI library and
 basic libraries that work together well with each other, and then a
 number of applications and other libraries compiled with that set of
 tools and thus often dependent on those. We use toolchains based on the
-Intel and GNU compilers, and refresh them twice a year, leading to
+Intel and GNU compilers, and refresh them up to twice a year, leading to
 version numbers like 2023a and 2023b for the first and second
 refresh of a given year. Some tools are installed outside a toolchain,
 e.g., additional versions requested by a small group of users for

--- a/source/software/using_software.rst
+++ b/source/software/using_software.rst
@@ -14,7 +14,7 @@ basic libraries that work together well with each other, and then a
 number of applications and other libraries compiled with that set of
 tools and thus often dependent on those. We use toolchains based on the
 Intel and GNU compilers, and refresh them twice a year, leading to
-version numbers like 2014a, 2014b or 2015a for the first and second
+version numbers like 2023a and 2023b for the first and second
 refresh of a given year. Some tools are installed outside a toolchain,
 e.g., additional versions requested by a small group of users for
 specific experiments, or tools that only depend on basic system

--- a/source/software/using_software.rst
+++ b/source/software/using_software.rst
@@ -1,41 +1,54 @@
 Using software
 ==============
 
-The best way to get a complete list of all available software in a
-particular cluster can be obtained by typing:
+The scientific software stack on the VSC clusters is mainly exposed via
+:ref:`modules <module_system_basics>`. :ref:`Toolchains <toolchains>` are
+an important concept in this context.
 
-::
-
-   $ module av
-
-In order to use the software stack in the HPC cluster, the user should work
-with the :ref:`module system <module system basics>`.
+For basic information on the module system and more site-specific information,
+please consult the following pages:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
-   software_stack
-
-On the newer systems, we use the same naming conventions for packages on all
-systems. Due to the ever expanding list of packages, we've also made some
-adjustments and don't always show all packages. Be sure to check out
-:ref:`how you can see specialized software modules
-<specialized software stacks>`.
+   module_system_basics
+   ../gent/setting_up_the_environment_using_lmod_at_the_hpc_ugent_clusters
 
 
-.. seealso::
+Background
+----------
 
-   Since August 2016, a different implementation of the module system has been
-   implemented on UGent, VUB, UAntwerpen Tier-2 systems and KU Leuven's Genius
-   cluster, called `Lmod`_. Though highly compatible with the aforementioned
-   module system used on the other clusters, it has some extra capabilities and
-   differences:
+Software installation and maintenance on HPC infrastructure such as the
+VSC clusters poses a number of challenges not encountered on a
+workstation or a departmental cluster. For many libraries and programs,
+multiple versions have to installed and maintained as some users require
+specific versions of those. In turn, those libraries or executables sometimes
+rely on specific versions of other libraries, further complicating the
+matter.
 
+The way Linux finds the right executable for a command, and a program
+loads the right version of a library or a plug-in, is through so-called
+environment variables. These can, e.g., be set in your shell
+configuration files (e.g., ``.bashrc``), but this requires a certain
+level of expertise. Moreover, getting those variables right is tricky
+and requires knowledge of where all files are on the cluster. Having to
+manage all this by hand is clearly not an option.
 
-   .. toctree::
-      :maxdepth: 2
+We deal with this on the VSC clusters in the following way. First, we've
+defined the concept of a :ref:`toolchain <toolchains>`. They consist of
+a set of compilers, MPI library and
+basic libraries that work together well with each other, and then a
+number of applications and other libraries compiled with that set of
+tools and thus often dependent on those. We use tool chains based on the
+Intel and GNU compilers, and refresh them twice a year, leading to
+version numbers like 2014a, 2014b or 2015a for the first and second
+refresh of a given year. Some tools are installed outside a toolchain,
+e.g., additional versions requested by a small group of users for
+specific experiments, or tools that only depend on basic system
+libraries. Second, we use :ref:`modules <module_system_basics>` to manage the
+environment and all dependencies and possible conflicts
+between various programs and libraries.
 
-      ../gent/setting_up_the_environment_using_lmod_at_the_hpc_ugent_clusters
 
 Packages with additional documentation
 --------------------------------------


### PR DESCRIPTION
In part to address some feedback from the last user survey, this PR proposes the following kind of changes:

- [x] using a dedicated "Module system basics" page with just this kind of info
- [x] replacing its examples with (very) old modules by newer ones
- [x] converting the current "Genius to Rocky" page to one with Leuven-specific module system info
       (and so removing the Rocky 8 migration info, which is now quite some time behind us)

(I've based this in part on the https://github.com/hpcleuven/VscDocumentation/tree/feature/module_documentation branch, but e.g. did not include its attempt at merging the site-specific module information, which I propose to leave for a future PR ;-)

@boegel  @smoors @backelj :  just pinging you as well in case you want to chime in, since this also touches on some 'common' parts.
