### PR TITLE
Malware-free download link for FileZilla

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -338,7 +338,7 @@ rst_prolog += """
 .. _Cygwin: https://www.cygwin.com/
 .. _Docker: https://www.docker.com/
 .. _docs.globus.org: https://docs.globus.org
-.. _download FileZilla: https://filezilla-project.org/download.php?type=client
+.. _download FileZilla: https://filezilla-project.org/download.php?show_all=1
 .. _Eclipse download page: http://www.eclipse.org/downloads
 .. _Eclipse packages download page: https://www.eclipse.org/downloads/packages/
 .. _Eclipse: https://www.eclipse.org/


### PR DESCRIPTION
I got a nice headsup from a user who mentioned that the current FileZilla download link leads to a copy that contains ads and malware. As explained [in this link](https://www.reddit.com/r/HTML/comments/1d7ko9r/is_filezilla_a_safe_program/), the current download URL leads to the quick download which is a 'sponsored version' including adware and gets detected by security as malware. For users machines equipped with malware detection, this is quite a headache. 

Instead, I replaced the download link with the direct download page from FileZilla: https://filezilla-project.org/download.php?show_all=1
