### PR TITLE
KULeuven correct GPU resource proportions

### DIFF
--- a/source/leuven/slurm_specifics.rst
+++ b/source/leuven/slurm_specifics.rst
@@ -218,45 +218,27 @@ per GPU is provided in the table below.
      - 16
      - 187200
 
-The following remarks apply when submitting jobs to the GPU partitions:
+The submit filter will issue a warning if a job requests more cores or memory per GPU
+than what is listed above. If this happens, please adjust the Slurm options accordingly
+for your future jobs.
 
-* If a job requests more cores or memory per every GPU as listed above, the job
-  will not be submitted to the queue.
-  Instead, an informative message will be sent to the standard error stream.
-* A job may request less cores and/or memory per GPU than the maximum limit in the table above.
-* Instead of specifying ``--mem`` or ``--mem-per-cpu``, a job may request ``mem-per-gpu``.
-  In that case, the maximum value specified for ``--mem`` applies to ``--mem-per-gpu``, too.
-* For restricting maximum memory for GPU jobs, one has to choose one of the ``--mem``, ``--mem-per-cpu``,
-  or ``--mem-per-gpu`` options.
-* For multi-GPU jobs, the multiple of resouces from the table above applies.
-  E.g. the maximum allowed resources for a two-GPU job on wICE ``gpu_a100`` partition would look like:
+As an example, suppose that you need two A100 GPUs for your calculation, with just
+one core per GPU but with as much CPU memory as you can get. Such a job can be
+submitted as follows:
 
   .. code-block:: bash
-
+     # This job will get less than 18 cores per GPU, so this requirement is satisfied
+     # It will receive 126000 MiB of CPU memory per GPU, which is the maximum
+     # we can get without getting the submit filter warning
      sbatch --account=lp_myproject --clusters=wice --partition=gpu_a100 \
-            --nodes=1 --ntasks=36 --gpus-per-node=2 --mem=252000m \
+            --nodes=1 --ntasks-per-node=2 --gpus-per-node=2 --mem=252000 \
             myjobscript.slurm
 
-  Similarly, multi-node multi-GPU jobs can take up the entire cores and memory of the nodes.
-  But, resources can be specified per node and device:
+For more examples of valid GPU jobs, have a look at the
+:ref:`Genius <genius_t2_leuven>` and :ref:`wICE <wice_t2_leuven>`
+quickstart guides.
 
-
-  .. code-block:: bash
-
-     sbatch --account=lp_myproject --clusters=wice --partition=gpu_a100 \
-            --nodes=2 --ntasks-per-gpu=18 --gpus-per-node=4 --mem-per-gpu=126000m \
-            myjobscript.slurm
-
-* Due to the Multi-Instance GPU (MIG) configuration of the Nvidia A100 GPUs on the
-  wICE ``interactive`` partition, specifying ``--gpus-per-node=1`` will result in
-  allocation of 1/7th of the physical device.
-  One cannot request any additional GPU instance from this partition.
-* Slurm supports `GPU sharding <https://slurm.schedmd.com/gres.html#Sharding>`_, and this
-  feature is enabled for all our GPUs.
-  The maximum shards per each GPU is equivalent to the number of cores of the compute host.
-  When requesting GPU shards, *no* resource limits apply.
-  In this case, the user is supposed to request the same number of cores as the requested
-  GPU shards.
-  It is also adviced to leave out memory specifications, and rely on the default memory per core.
-* All the examples given in the :ref:`Genius <genius_t2_leuven>` and :ref:`wICE <wice_t2_leuven>`
-  quick start guides fully comply with the correct resource proportions.
+Aside from options such as ``--ntasks-per-node`` and ``--cpus-per-task``
+(for CPU cores) and ``--mem`` and ``--mem-per-cpu`` (for CPU memory),
+keep in mind that Slurm also offers options like ``--cpus-per-gpu`` and
+``--mem-per-gpu``.

--- a/source/leuven/slurm_specifics.rst
+++ b/source/leuven/slurm_specifics.rst
@@ -239,10 +239,8 @@ For more examples of valid GPU jobs, have a look at the
 :ref:`Genius <genius_t2_leuven>` and :ref:`wICE <wice_t2_leuven>`
 quickstart guides.
 
-Slurm offers advanced options for fine-grained resource specifications for GPU jobs.
-For instance, one may combine ``--ntasks`` and ``--cpus-per-gpu`` to limit the maximum
-cores per GPU.
-Similarly, one may specify the (minimum) CPU memory per GPU using the ``--mem-per-gpu``
-option.
-In either case, the maximum CPU resource limits from the table above shall be respected.
-
+Aside from options such as ``--ntasks-per-node`` and ``--cpus-per-task``
+(for CPU cores) and ``--mem`` and ``--mem-per-cpu`` (for CPU memory),
+Slurm also offers options like ``--cpus-per-gpu`` and ``--mem-per-gpu``.
+When using these options, make sure that the requested CPU cores
+and CPU memory per GPU does not exceed the limits mentioned in the table above.

--- a/source/leuven/slurm_specifics.rst
+++ b/source/leuven/slurm_specifics.rst
@@ -244,5 +244,5 @@ For instance, one may combine ``--ntasks`` and ``--cpus-per-gpu`` to limit the m
 cores per GPU.
 Similarly, one may specify the (minimum) CPU memory per GPU using the ``--mem-per-gpu``
 option.
-In either case, the maximum CPU limits from the table above shall be respected.
+In either case, the maximum CPU resource limits from the table above shall be respected.
 

--- a/source/leuven/slurm_specifics.rst
+++ b/source/leuven/slurm_specifics.rst
@@ -179,12 +179,11 @@ A few notes on this feature:
 GPU, memory and core proportions
 --------------------------------
 
-The Genius and wICE GPU nodes are equipped with either 4 or 8 devices.
-However, different hosts offer different number of cores and RAM memory.
-Consequently, every compute job is allowed to request a maximum amount of memory
-and CPU cores per node for each GPU device.
-The following table gives an overview of the maximum core-to-device and memory-to-device
-proportion for the current ``gpu_*`` partitions:
+Jobs sent to ``gpu_*`` partitions are expected to only request a proportionate
+amount of CPU resources. For example, a single-GPU job sent to a partition
+with 4 GPUs per node should only request up to 1/4th of the available
+CPU cores and CPU memory. An overview of the maximal CPU resources
+per GPU is provided in the table below.
 
 .. list-table:: Memory and cores per GPU
    :widths: 20 20 20 20 20

--- a/source/leuven/slurm_specifics.rst
+++ b/source/leuven/slurm_specifics.rst
@@ -179,8 +179,8 @@ A few notes on this feature:
 CPU resource limits in GPU jobs
 -------------------------------
 
-Jobs sent to ``gpu_*`` partitions are expected to only request a proportionate
-amount of CPU resources. For example, a single-GPU job sent to a partition
+Jobs sent to the ``gpu_*`` partitions are expected to only request a proportionate
+amount of CPU resources. For example, a single-GPU job submitted to a partition
 with 4 GPUs per node should only request up to 1/4th of the available
 CPU cores and CPU memory. An overview of the maximal CPU resources
 per GPU is provided in the table below.
@@ -191,11 +191,11 @@ per GPU is provided in the table below.
 
    * - Cluster
      - Partition(s)
-     - Cores
-     - Memory
+     - Max Cores
+     - Max Memory
    * -
      -
-     - (MiB)
+     -
      - (MiB)
    * - Genius
      - ``gpu_p100*``
@@ -218,27 +218,31 @@ per GPU is provided in the table below.
      - 16
      - 187200
 
-The submit filter will issue a warning if a job requests more cores or memory per GPU
-than what is listed above. If this happens, please adjust the Slurm options accordingly
-for your future jobs.
+If a job requests more cores or memory per GPU than listed above, you will receive a
+warining message.
+In this case, please adjust the Slurm options accordingly for your future jobs.
 
 As an example, suppose that you need two A100 GPUs for your calculation, with just
-one core per GPU but with as much CPU memory as you can get. Such a job can be
-submitted as follows:
+one core per GPU but with as much CPU memory as you can get.
+Such a job can be submitted as follows:
 
-  .. code-block:: bash
-     # This job will get less than 18 cores per GPU, so this requirement is satisfied
-     # It will receive 126000 MiB of CPU memory per GPU, which is the maximum
-     # we can get without getting the submit filter warning
-     sbatch --account=lp_myproject --clusters=wice --partition=gpu_a100 \
-            --nodes=1 --ntasks-per-node=2 --gpus-per-node=2 --mem=252000 \
-            myjobscript.slurm
+.. code-block:: bash
+
+   sbatch --account=lp_myproject --clusters=wice --partition=gpu_a100 \
+          --nodes=1 --ntasks-per-node=2 --gpus-per-node=2 --mem=252000m \
+          myjobscript.slurm
+
+In practice, 18 CPU cores and 126000 MiB CPU memory will be allocated per GPU,
+and no warning will be raised.
 
 For more examples of valid GPU jobs, have a look at the
 :ref:`Genius <genius_t2_leuven>` and :ref:`wICE <wice_t2_leuven>`
 quickstart guides.
 
-Aside from options such as ``--ntasks-per-node`` and ``--cpus-per-task``
-(for CPU cores) and ``--mem`` and ``--mem-per-cpu`` (for CPU memory),
-keep in mind that Slurm also offers options like ``--cpus-per-gpu`` and
-``--mem-per-gpu``.
+Slurm offers advanced options for fine-grained resource specifications for GPU jobs.
+For instance, one may combine ``--ntasks`` and ``--cpus-per-gpu`` to limit the maximum
+cores per GPU.
+Similarly, one may specify the (minimum) CPU memory per GPU using the ``--mem-per-gpu``
+option.
+In either case, the maximum CPU limits from the table above shall be respected.
+

--- a/source/leuven/slurm_specifics.rst
+++ b/source/leuven/slurm_specifics.rst
@@ -185,44 +185,37 @@ with 4 GPUs per node should only request up to 1/4th of the available
 CPU cores and CPU memory. An overview of the maximal CPU resources
 per GPU is provided in the table below.
 
-.. list-table:: Memory and cores per GPU
-   :widths: 20 20 20 20 20
+.. list-table:: Available CPU cores and CPU memory per GPU
+   :widths: 20 20 20 20
    :header-rows: 2
 
    * - Cluster
      - Partition(s)
-     - CPU cores
-     - ``--mem-per-cpu``
-     - ``--mem``
+     - Cores
+     - Memory
    * -
-     -
      -
      - (MiB)
      - (MiB)
    * - Genius
      - ``gpu_p100*``
      - 9
-     - 5000
      - 45000
    * - Genius
      - ``gpu_v100*``
      - 4
-     - 21000
      - 84000
    * - wICE
      - ``interactive``
      - 8
-     - 7500
      - 60000
    * - wICE
      - ``gpu|gpu_a100``
      - 18
-     - 7000
      - 126000
    * - wICE
      - ``gpu_h100``
      - 16
-     - 11700
      - 187200
 
 The following remarks apply when submitting jobs to the GPU partitions:

--- a/source/leuven/slurm_specifics.rst
+++ b/source/leuven/slurm_specifics.rst
@@ -174,10 +174,10 @@ A few notes on this feature:
   called ``interactive``. For jobs on that partition this feature is
   irrelevant.
 
-.. _gpu_cores_mem:
+.. _cpu_resource_limits_in_gpu_jobs:
 
-GPU, memory and core proportions
---------------------------------
+CPU resource limits in GPU jobs
+-------------------------------
 
 Jobs sent to ``gpu_*`` partitions are expected to only request a proportionate
 amount of CPU resources. For example, a single-GPU job sent to a partition


### PR DESCRIPTION
Recently, a [`job_submit.lua` plugin](https://slurm.schedmd.com/job_submit_plugins.html) got deployed on our production sites to impose a new GPU usage policy. Through the plugin, we ensure that each job requests a maximum allowed proportion of cores and memory per every requested GPU. This PR adds a new section to the [specific Slurm instructions](https://docs.vscentrum.be/leuven/slurm_specifics.html) relevant for the KU Leuven site.