### PR TITLE
typo fixes for RStudio

### DIFF
--- a/source/leuven/services/openondemand.rst
+++ b/source/leuven/services/openondemand.rst
@@ -418,15 +418,16 @@ RStudio Server
 
 This interactive app allows you to run an RStudio session on the cluster.
 In the 'Toolchain year and R version' drop-down menu, you can choose the version
-of R module that would be loaded for your session (such as `R/4.2.2-foss-2022b`).
-Additionally, the `R-bundle-CRAN` and `R-bundle-Bioconductor` modules can be loaded
+of R module that would be loaded for your session (such as ``R/4.2.2-foss-2022b``).
+Additionally, the ``R-bundle-CRAN`` and ``R-bundle-Bioconductor`` modules can be loaded
 on top of the base R module to provide easy access to hundreds of preinstalled packages.
 
-It is also possible to use locally installed R packages with RStudio, see :ref:`R package management<r_package_management_standard_lib>`.
+It is also possible to use locally installed R packages with RStudio,
+see e.g. :ref:`R package management<r_package_management_standard_lib>`.
 RStudio furthermore allows to create RStudio projects to manage your
 R environments. When doing so, we recommend to select the
 `renv <https://rstudio.github.io/renv/articles/renv.html>`_ option
-to ensure a completely independent R environment. Without `renv`,
+to ensure a completely independent R environment. Without using ``renv``,
 loading an RStudio project may lead to incomplete R library paths.
 
 For more information on how to use RStudio, check out the `official documentation <https://docs.posit.co/ide/user/>`__.
@@ -440,7 +441,7 @@ For more information on how to use RStudio, check out the `official documentatio
   Another solution is to click the three dots on the right (...) and enter your path.
 - The 'Tools-Install packages' interface does not allow you to select any other path than the default in your ``$VSC_HOME``.
   It is recommended to use the ``install.packages()`` function instead.
-- RStudioServer will by default store the RStudio cache in ``$VSC_HOME/.local/share/rstudio``.
+- By default, RStudio Server stores its cache in ``$VSC_HOME/.local/share/rstudio``.
   This cache can get very large, and cause you to exceed the quota of your home directory.
   To avoid this, you can redirect this cache to your data directory by setting the ``$XDG_DATA_HOME``
   variable in your ``~/.bashrc``:
@@ -449,10 +450,10 @@ For more information on how to use RStudio, check out the `official documentatio
 
     echo "export XDG_DATA_HOME=$VSC_DATA/.local/share" >> ~/.bashrc
 
-- Additionally, it is advised to change the default behaviour of RStudio to not restore .RData
-  into the workspace on start up and to never Save the workspace to .RData on exit.
+- Additionally, it is advised to change the default behaviour of RStudio to not restore ``.RData``
+  into the workspace on start up and to never Save the workspace to ``.RData`` on exit.
   You can do this via the RStudio interface:
-  Tools > Global Options > General > Workspace
+  Tools > Global Options > General > Workspace.
 
 Tensorboard
 -----------


### PR DESCRIPTION
This PR proposes few subtle typesetting improvements and typo fixes (missing space or a full-stop), only for the RStudio subsection.