### PR TITLE
Document use of wrapper script for compiled MATLAB code

### DIFF
--- a/source/compute/software/matlab_getting_started.rst
+++ b/source/compute/software/matlab_getting_started.rst
@@ -218,7 +218,8 @@ In addition to the MATLAB executable (``main`` in this example), the compiler
 also generates a wrapper file (``run_main.sh`` in this example) that can be
 used to invoke the MATLAB executable. It sets environment variable LD_LIBRARY_PATH
 to make sure that the MATLAB runtime libraries can be found by the executable,
-and next runs the executable.
+and next runs the executable. (The compiler generates a few other files as well,
+these can be ignored.)
 
 The wrapper expects a first argument that provides the rootdir of the MATLAB
 installation that is being used. With a MATLAB module, that rootdir is given

--- a/source/compute/software/matlab_getting_started.rst
+++ b/source/compute/software/matlab_getting_started.rst
@@ -30,7 +30,7 @@ Interactive use
 ---------------
 
 -  Interactive use is possible, but is not the preferred way of using
-   MATLAB on the cluster! Use batch processing of compiled MATLAB code
+    on the cluster! Use batch processing of compiled MATLAB code
    instead.
 -  If there is an X Window System server installed on your PC (as is by
    default the case under :ref:`linux_client`; you can use
@@ -214,14 +214,14 @@ The deployed executable is compiled to run using a single thread via
 the option ``-singleCompThread``. This is important when a number of processes
 are to run concurrently on the same node (e.g., worker framework).
 
-In addition to the matlab executable (``main`` in this example``), the compiler
+In addition to the MATLAB executable (``main`` in this example), the compiler
 also generates a wrapper file (``run_main.sh`` in this example) that can be
-used to invoke the matlab executable. It sets environment variable LD_LIBRARY_PATH
-to make sure that the matlab runtime libraries can be found by the executable,
+used to invoke the MATLAB executable. It sets environment variable LD_LIBRARY_PATH
+to make sure that the MATLAB runtime libraries can be found by the executable,
 and next runs the executable.
 
-The wrapper expects a first argument that provides the rootdir of the matlab
-installation that is being used. With a matlab module, that rootdir is given
+The wrapper expects a first argument that provides the rootdir of the MATLAB
+installation that is being used. With a MATLAB module, that rootdir is given
 by environment variable EBROOTMATLAB. Additional arguments are passed on to the 
 compiled executable.
 
@@ -271,7 +271,7 @@ Run the compiler::
 
     $ mcc -m fibonacci
 
-This creates matlab executable file ``fibonacci`` and wrapper file
+This creates MATLAB executable file ``fibonacci`` and wrapper file
 ``run_fibonnacci.sh``.
 
 You can now run your application as follows::

--- a/source/compute/software/matlab_getting_started.rst
+++ b/source/compute/software/matlab_getting_started.rst
@@ -30,7 +30,7 @@ Interactive use
 ---------------
 
 -  Interactive use is possible, but is not the preferred way of using
-    on the cluster! Use batch processing of compiled MATLAB code
+   on the cluster! Use batch processing of compiled MATLAB code
    instead.
 -  If there is an X Window System server installed on your PC (as is by
    default the case under :ref:`linux_client`; you can use

--- a/source/compute/software/matlab_getting_started.rst
+++ b/source/compute/software/matlab_getting_started.rst
@@ -214,6 +214,17 @@ The deployed executable is compiled to run using a single thread via
 the option ``-singleCompThread``. This is important when a number of processes
 are to run concurrently on the same node (e.g., worker framework).
 
+In addition to the matlab executable (``main`` in this example``), the compiler
+also generates a wrapper file (``run_main.sh`` in this example) that can be
+used to invoke the matlab executable. It sets environment variable LD_LIBRARY_PATH
+to make sure that the matlab runtime libraries can be found by the executable,
+and next runs the executable.
+
+The wrapper expects a first argument that provides the rootdir of the matlab
+installation that is being used. With a matlab module, that rootdir is given
+by environment variable EBROOTMATLAB. Additional arguments are passed on to the 
+compiled executable.
+
 .. note::
 
    -  Parameters are always considered as strings, and thus have to be
@@ -260,15 +271,16 @@ Run the compiler::
 
     $ mcc -m fibonacci
 
-An executable file `fibonacci` is created.
+This creates matlab executable file ``fibonacci`` and wrapper file
+``run_fibonnacci.sh``.
 
 You can now run your application as follows::
 
-   ./fibonacci 6
+   $ ./run_fibonacci.sh $EBROOTMATLAB 6
    Fibonacci 6 -> 5
-   $ ./fibonacci 8
+   $ ./run_fibonacci.sh $EBROOTMATLAB 8
    Fibonacci 8 -> 13
-   $ ./fibonacci 45
+   $ ./run_fibonacci.sh $EBROOTMATLAB 45
    Fibonacci 45 -> 701408733
 
 
@@ -305,7 +317,7 @@ Compile the file::
 
 Run the executable::
 
-   ./multi_fibo
+   ./run_multi_fibo.sh $EBROOTMATLAB
    n =
        10    11    12    13    14    15    16    17    18    19    20
    Fibonacci 10 -> 34

--- a/source/compute/software/matlab_getting_started.rst
+++ b/source/compute/software/matlab_getting_started.rst
@@ -30,7 +30,7 @@ Interactive use
 ---------------
 
 -  Interactive use is possible, but is not the preferred way of using
-   on the cluster! Use batch processing of compiled MATLAB code
+   MATLAB on the cluster! Use batch processing of compiled MATLAB code
    instead.
 -  If there is an X Window System server installed on your PC (as is by
    default the case under :ref:`linux_client`; you can use


### PR DESCRIPTION
When installing MATLAB using EasyBuild, it is advised not to add the paths to the MATLAB runtime libraries to LD_LIBRARY_PATH in the module file (see https://github.com/easybuilders/easybuild-easyblocks/pull/2981). But these runtime libraries are required when running comiled MATLAB code, and so LD_LIBRARY_PATH needs those paths when running compiled MATLAB code. The preferred solution is to use the wrapper script for a MATLAB executable that is generated by the MATLAB compiler when compiling MATLAB scripts (https://github.com/easybuilders/easybuild-easyblocks/issues/2965#issuecomment-1665317981). The wrapper expects a first argument that provides the rootdir of the MATLAB installation that is being used. With a MATLAB module, that rootdir is given by EasyBuild environment variable EBROOTMATLAB. 

Both UGent and VUB already recommend using the wrapper script in their site-specific MATLAB documentation (https://hpc.vub.be/docs/software/usecases/#batch-mode and https://docs.hpc.ugent.be/Windows/MATLAB/#matlab-job-script), but the discussion of running compiled MATLAB code in the general VSC documentation tacitly assumed that LD_LIBRARY_PATH was set correctly, such that the MATLAB executable could be invoked directly. This PR adds the use of the wrapper script and EBROOTMATLAB to that general documentation. 