### PR TITLE
Feature/vsc rproject

### DIFF
--- a/source/compute/portal/ondemand/rstudio-server.rst
+++ b/source/compute/portal/ondemand/rstudio-server.rst
@@ -22,13 +22,13 @@ that will be loaded for your session (such as ``R/4.4.1-gfbf-2023b``).
 If needed, the ``R-bundle-Bioconductor`` module can be loaded as well to get access
 to many preinstalled bioinformatics packages.
 
-It is also possible to use locally installed R packages with RStudio, see e.g.
-:ref:`R package management<r_package_management_standard_lib>`.  RStudio
-furthermore allows to create RStudio projects to manage your R environments.
-When doing so, we recommend selecting the `renv
-<https://rstudio.github.io/renv/articles/renv.html>`_ option to ensure a
-completely independent R environment. Without using ``renv``, loading an RStudio
-project may lead to incomplete R library paths.
+It is also possible to use locally installed R packages with RStudio, see:
+:ref:`R package management<r_package_management_standard_lib>`. 
+
+RStudio furthermore allows to create RStudio Projects to manage your R environments.
+When doing so, we recommend using the tool :ref:`vsc-Rproject<vsc-Rproject>` which
+provides a convenient way to manage your R environments when working with RStudio Projects
+on our HPC systems.
 
 For more information on how to use RStudio, check out the `official
 documentation <https://docs.posit.co/ide/user/>`__.

--- a/source/compute/software/r_package_management.rst
+++ b/source/compute/software/r_package_management.rst
@@ -20,6 +20,32 @@ or that the package versions do not meet your requirements. In this case you wil
 need to locally install those packages, as will be described below. Do not hesitate
 to contact your local support team when encountering issues during these local installations.
 
+
+.. _r_package_management_with_vsc_rproject:
+
+RStudio Projects and HPC
+------------------------
+
+The general recommended way of managing your R projects is by using RStudio Projects.
+RStudio Projects provide a self-contained, organized environment. Each project has 
+its own directory, workspace and history which helps avoid conflicts between different
+analyses. This structure encourages best practices such as modular code, as well as the 
+use of relative filepaths and version control (e.g. git integration). 
+
+However, using RStudio Projects on a heterogenous HPC system posses a couple challenges.
+A first challenge stems from the fact that R packages are version dependent. Therefore you want your
+RStudio Project to be somehow associated with a specific R installation.
+While a package manager like `renv <https://rstudio.github.io/renv/articles/renv.html>`_ does facilitate this, it wasn't developed with heterogenous HPC hardware in mind.
+This also immediately introduces the second challenge. By default, when installing R
+packages, they are compiled with the specific CPU microarchitecture of the host compute node in mind. 
+Ideally you would want your project's package library to be compatible with as many architectures as
+possible without sacrificing performance. 
+
+With these difficulties in mind, we have developed :ref:`vsc-Rproject<vsc-Rproject>` which provides
+a convenient way to manage RStudio Project environments in a way that is compatible with our
+heterogenous HPC infrastructure. 
+
+
 .. _r_package_management_standard_lib:
 
 Standard R package installation

--- a/source/compute/software/software_development.rst
+++ b/source/compute/software/software_development.rst
@@ -38,5 +38,6 @@ Libraries
    blas_and_lapack
    perl_package_management
    python_package_management
+   vsc_rproject
    r_package_management
    r_devtools

--- a/source/compute/software/vsc_rproject.rst
+++ b/source/compute/software/vsc_rproject.rst
@@ -1,0 +1,199 @@
+.. _vsc-Rproject:
+
+vsc-Rproject
+============
+
+Introduction
+------------
+
+vsc-Rproject is an in-house developed command-line tool that integrates the use of
+RStudio Projects into our HPC environment. It facilitates the creation, management
+and use of such vsc-Rproject environments. 
+
+.. note::
+  In what follows, the term "vsc-Rproject environment" will always refer to
+  the custom RStudio Project environment that is created by the vsc-Rproject tool.
+  When refering to the RStudio Project folder specifically, the term "RStudio Project" will be used instead.
+
+How to use
+----------
+
+vsc-Rproject can be used by simply loading the module.
+
+.. code:: bash
+
+       $ module load vsc-Rproject
+
+
+Then, use the `vsc-rproject` command to use its different functionalities.
+
+.. code:: bash
+
+       $ vsc-rproject --help
+       $ vsc-rproject --version
+
+The `vsc-rproject` command provides four sub-commands that can be used to `configure` default behaviour
+or `create`, `activate`, or `deactivate` a vsc-Rproject environment.
+In what follows, the use of each of these sub-commands will be further explained.
+
+.. _sub-command-create:
+
+sub-command: create
+~~~~~~~~~~~~~~~~~~~
+
+The `create` sub-command allows you to create a new vsc-Rproject environment.
+
+When creating a such environment, the only required argument is a project name. 
+
+It is however strongly encouraged to also provide a "modules file".
+This is a simple text file listing one module (full name and version) per line.
+When providing a modules file, vsc-Rproject will ensure that these modules
+are always loaded upon activating the vsc-Rproject environment.
+If no modules file is provided, the default R module will be used instead.
+
+The following command will create a modules.txt file in your home directory,
+containing the following modules:
+
+- `R/4.4.1-gfbf-2023b`
+- `R-bundle-CRAN/2024.06-foss-2023b`
+
+.. code:: bash
+
+       $ printf "R/4.4.1-gfbf-2023b\nR-bundle-CRAN/2024.06-foss-2023b\n" > ~/modules.txt
+
+
+.. note::
+
+  When you specify a modules file, it should always contain the R module.
+
+To create a new vsc-Rproject environment using this modules file, run the following command:
+
+.. code:: bash
+
+       $ vsc-rproject create NewProject --modules="$VSC_HOME/modules.txt"
+
+This will create a new RStudio Project named "NewProject" at the default location: `$VSC_DATA/Rprojects`.
+The modules.txt file will be used when creating the project and stored in 
+`$VSC_DATA/Rprojects/.vsc-rproject/modules.env`.
+
+.. note::
+
+  If you wish to update the modules list for an existing project, you should manually
+  add it to the `.vsc-rproject/modules.env` file.
+
+
+Additionally, a project specific `.Renviron`, `.Rprofile` and `.R/Makevars` file will be created.
+
+The `.Renviron` will set the `R_LIBS_USER` variable to point to the project's R package library.
+This can be found at the root of the project, under `/library/<OS>/R`.
+
+The `.Rprofile` will be configured to set the CRAN mirror to "https://cloud.r-project.org" (default)
+and set the `R_MAKEVARS_USER` variable to point to the project's `.R/Makevars` file.
+
+The `.R/Makevars` file can be used to control the compilation process when installing 
+new R packages by modifying the compiler flags. vsc-Rproject's default behaviour 
+is to change the `-march` compiler flag for all relevant compilers from "native"
+to "x86-64-v4". 
+
+.. note::
+
+  While compiling with "-march=native" will result in better performance for a single
+  type of CPU microarchitecture, the "-march=x86-64-v4" setting marginally compromises
+  performance, to allow for a more generic installation compatible with microarchitectures
+  from skylake or more recent. For most users this will be the more desirable option 
+  as it makes switching between different types of compute nodes a lot easier.
+
+.. warning::
+  The `-march=x86-64-v4` flag is used as the default for microarchitecture optimization 
+  targeting Intel Skylake and newer processors. However, this flag is only supported
+  in GCC version 11 and later. If you are using an older version of R that relies
+  on an earlier GCC version, `-march=x86-64-v4` may not be recognized.
+  In such cases, you can run `gcc --target-help` to view the list of supported 
+  -march values and choose a more appropriate setting.
+
+
+If you want to enable git within your RStudio Project you can add the `--enable-git` flag.
+To automatically activate the vsc-Rproject environment after creating it, use `--activate`
+
+If you are not satisfied with the default behaviour, you can modify the behaviour
+of `vsc-rproject create` by providing additional command-line arguments.
+You can specify `--location` to create your project in a different location.
+The `--cran` argument can be used to provide a specific CRAN mirror for your project.
+Finally `--march` allows you to choose a different the microarchitecture optimization
+for your project.
+
+
+For more information, see:
+
+.. code:: bash
+
+       $ vsc-rproject create --help
+
+
+.. note::
+
+  Alternatively, you may also want to  modify your default settings more permanently via `vsc-rproject configure`.
+  See :ref:`sub-command-configure` for more details.
+
+.. _sub-command-activate:
+
+sub-command: activate
+~~~~~~~~~~~~~~~~~~~~~
+
+The `activate` sub-command can be used to activate an already existing vsc-Rproject environment.
+
+.. code:: bash
+
+       $ vsc-rproject activate NewProject
+
+Activating a vsc-Rproject environment will load all the relevant modules listed in the modules file and
+set the `$VSC_RPROJECT` environment variable which can be used to access the root directory of the project. 
+
+.. _sub-command-deactivate:
+
+sub-command: deactivate
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The `deactivate` sub-command deactivates the active vsc-Rproject environment. 
+Deactivating a project will purge all loaded modules except for the cluster module 
+and the vsc-Rproject module itself. Additionally, it will unset the `$VSC_RPROJECT` variable.
+ 
+.. code:: bash
+
+       $ vsc-rproject deactivate
+
+
+.. _sub-command-configure:
+
+sub-command: configure
+~~~~~~~~~~~~~~~~~~~~~~
+
+If you wish to change the default behaviour of vsc-Rproject, you can configure your
+personal default settings with the `configure` sub-command.
+
+.. note::
+
+  You can at all times check your current default settings with `vsc-rproject --defaults`.
+
+`vsc-rproject configure` allows you to set your prefered default R with `--default-r`.
+You may also set a new default location for your RStudio Projects with `--location`.
+Finally you can still configure your prefered default CRAN mirror using `--cran` 
+and the default `-march` compiler settings with `--march`
+
+These personal configurations will be stored in `$VSC_HOME/.vsc-rproject-config`.
+
+To further support working on a heterogeneous HPC environment the `$VSC_RPROJECT_CONFIG` 
+environment variable can be used to specify an alternative `.vsc-rproject-config` file.
+This allows for switching between different configurations depending on your needs. 
+e.g. working on different clusters. 
+
+If `$VSC_RPROJECT_CONFIG` is set, `vsc-rproject` will consider it and use it if possible.
+If `$VSC_RPROJECT_CONFIG` is not set (default) `vsc-rproject` will use the default config file: `~/.vsc-rproject-config.`
+
+If at any point you wish to reset your configuration to the the original default settings, simply run:
+
+.. code:: bash
+
+       $ vsc-rproject configure --reset`
+
+


### PR DESCRIPTION
These are the suggested changes to our VscDocumentation page with regards to [vsc-Rproject](https://github.com/hpcleuven/vsc-Rproject).
- introduce vsc-Rproject as a tool and explains its functionalities
- update R package management to explain package management in the context of RStudio Projects on HPC
- update Open OnDemand RStudio Server documentation to no longer recommend the use of `renv` but instead advise `vsc-Rproject` when creating new RStudio Projects.

