### PR TITLE
Add information on Rocky 9 login nodes

### DIFF
--- a/source/leuven/wice_2_rocky9.rst
+++ b/source/leuven/wice_2_rocky9.rst
@@ -19,7 +19,8 @@ Important differences at the system level are listed below.
 | glibc       | 2.28             | 2.34                |
 +-------------+------------------+---------------------+
 
-Centrally installed modules have already been made available for Rocky 9, starting from toolchain 2021a.
+Centrally installed modules have already been made available for Rocky 9 for
+compute nodes that will be migrated, starting from toolchain 2021a.
 
 .. _timing:
 
@@ -70,6 +71,17 @@ The following query can be used to look up the currently reserved nodes::
 
 If you are not a ``vsc3*`` user and also want to test, please ask the
 helpdesk to add you to the reservation.
+
+Additionally some of the login nodes have been migrated as well. To land on a
+Rocky 9 login node, you need to connect to ``login-rocky9.hpc.kuleuven.be`` (as
+opposed to the ``login.hpc.kuleuven.be`` server you normally use). Note that
+the ``skylake`` architecture of the current login nodes is different from the
+architectures in the ``rocky9_pilot`` reservation. One consequence is that
+the ``module avail`` command might not show all modules relevant to
+compute jobs. The ``module spider`` command can be used as an alternative,
+see :ref:`the module system on Leuven clusters <leuven_module_system>` for
+background information. If you encounter inconsistencies between modules
+available for Rocky 8 and Rocky 9, please contact the support team.
 
 .. _expected impact:
 


### PR DESCRIPTION
Since two login nodes have been upgraded to Rocky 9 as well, the documentation page about it needed some updates.