### PR TITLE
Restrict VUB Open WebUI to anansi cluster only

### DIFF
--- a/source/compute/portal/ondemand/open-webui.rst
+++ b/source/compute/portal/ondemand/open-webui.rst
@@ -15,7 +15,6 @@ VSC clusters that support the Open WebUI app:
        :columns: 12 4 4 4
 
        * Tier-2 :ref:`Anansi <Anansi cluster>`
-       * Tier-2 :ref:`Hydra <Hydra cluster>`
 
 .. tab-set::
    :sync-group: vsc-sites


### PR DESCRIPTION
The Open WebUI OoD app at VUB will only run on the Anansi cluster, so remove mention of Hydra in the docs.