### PR TITLE
Add section about how to use EESSI to the Leuven module system page

### DIFF
--- a/source/leuven/leuven_module_system.rst
+++ b/source/leuven/leuven_module_system.rst
@@ -257,13 +257,14 @@ up EESSI first make the locally installed modules unavailable:
    module --force purge
    # Make EESSI available as a module
    export MODULEPATH=/cvmfs/software.eessi.io/init/modules/
-   # Load the default EESSI module
-   module load EESSI
+   # Load an EESSI module
+   module load EESSI/2023.06
 
 These setup commands need to be executed in each session where you want to use
-EESSI. After this, you can use the ``module`` commands as described above, but
-now those commands will interact with EESSI instead of locally installed
-modules. For example:
+EESSI. Note that you can search for other EESSI versions by running
+``module avail EESSI``. After loading the EESSI module, you can use the
+``module`` commands as described above, but now those commands will interact
+with the EESSI software stack instead of locally installed modules. For example:
 
 .. code-block:: shell
 


### PR DESCRIPTION
EESSI is now available on the KU Leuven/UHasselt Tier-2 cluster, so this PR adds some documentation on how to use it. I have a few remarks:

- Adding a section on EESSI will also be part of https://github.com/hpcleuven/VscDocumentation/pull/534, but since the completion of that PR will take some time, I decided to already add a section to the KU Leuven/UHasselt specific page about modules.
- The instructions are not entirely self-contained, they assume the user already has some knowledge of lmod for example. I think this is ok, since we currently still use locally installed modules as the default and we do not expect beginning users to make use of EESSI immediately.

@laraPPr @boegel While this PR only updates a KU Leuven page, your comments are of course very welcome :)