### PR TITLE
Update MFA page so it refers to the new location access restriction section

### DIFF
--- a/source/accounts/authentication.rst
+++ b/source/accounts/authentication.rst
@@ -66,6 +66,8 @@ clusters.
 
    mfa_login   
 
+.. _auth_location_access_restrictions:
+
 Location Access Restrictions
 ============================
 

--- a/source/accounts/authentication.rst
+++ b/source/accounts/authentication.rst
@@ -77,16 +77,16 @@ Location Access Restrictions
    .. tab-item:: KU Leuven/UHasselt
       :sync: kuluh
 
-      Beginning of March 2026 the firewall access to the HPC cluster will be resolved by the global KU Leuven firewall rules. This will have some impact in connections to the Tier-2 cluster:
+      Since March 2026, the firewall access to the HPC cluster is resolved by the global KU Leuven firewall rules. This impacts connections to the Tier-2 cluster.
      
-      There will be a difference between connecting from a managed KU Leuven laptop and unmanaged laptops.
+      There is a difference between connecting from a managed KU Leuven laptop and unmanaged laptops.
 
       KU Leuven managed laptops
             Use MFA (certificate) for connections both from Belgium and from abroad. No need to request :ref:`additional firewall login <additional_firewall>`.
 
       Non-managed laptops
             There are several possibilities to connect to the KU Leuven VSC clusters:
-                  *  From all locations (connecting from VPN B zone, from other VSC universities, from other Belgian IP addresses and from abroad):open the firewall access (https://firewall.vscentrum.be) and request a certificate. The firewall page only needs to be active when making new connections to the cluster.
+                  *  From all locations (connecting from VPN B zone, from other VSC universities, from other Belgian IP addresses and from abroad): open the firewall page (https://firewall.vscentrum.be) and request a certificate. The firewall page only needs to be active when making new connections to the cluster.
                   *  Exception for connections from within VSC network (_i.e._ other VSC clusters) - certificate is sufficient 
 
  

--- a/source/accounts/mfa_login.rst
+++ b/source/accounts/mfa_login.rst
@@ -12,11 +12,6 @@ VSC clusters:
 
 .. include:: clusters_mfa.rst
 
-.. note::
-
-   If you are connecting from abroad, it is necessary that you first authorize
-   your own connection on the `VSC Firewall`_
-
 Login to Open OnDemand
 ----------------------
 
@@ -32,6 +27,13 @@ Once that succeeds, you will automatically login to the Open OnDemand homepage.
 
 Connecting with an SSH agent
 ----------------------------
+
+.. note::
+
+   Additional access restrictions (for instance when connecting from abroad
+   or from a non-managed laptop) may apply, which require that you first
+   authorize your connection on the `VSC Firewall`_. See
+   :ref:`this page <auth_location_access_restrictions>` for more information.
 
 Using an :ref:`ssh agent` allows to store so-called SSH certificates which then
 are made available to any other client program needing to use that same connection.

--- a/source/accounts/mfa_login.rst
+++ b/source/accounts/mfa_login.rst
@@ -12,11 +12,6 @@ VSC clusters:
 
 .. include:: clusters_mfa.rst
 
-.. note::
-
-   If you are connecting from abroad, it is necessary that you first authorize
-   your own connection on the `VSC Firewall`_
-
 Login to Open OnDemand
 ----------------------
 
@@ -32,6 +27,13 @@ Once that succeeds, you will automatically login to the Open OnDemand homepage.
 
 Connecting with an SSH agent
 ----------------------------
+
+.. note::
+
+   Additional access restrictions (for instance when connecting from abroad
+   or from a non-managed laptop) may apply, which require that you first
+   authorize your connection on the `VSC Firewall`_. See
+   :ref:`this page <location_access_restrictions>` for more information.
 
 Using an :ref:`ssh agent` allows to store so-called SSH certificates which then
 are made available to any other client program needing to use that same connection.

--- a/source/leuven/tier2_hardware/tier2_login_nodes.rst
+++ b/source/leuven/tier2_hardware/tier2_login_nodes.rst
@@ -24,8 +24,11 @@ The access to both machines is possible
 Login infrastructure
 --------------------
 
-Direct login using SSH is possible to all login infrastructure without
-restrictions.
+.. note::
+
+   Restrictions apply for direct login using SSH. Make sure to read the
+   section on :ref:`access restrictions <auth_location_access_restrictions>`
+   before proceeding.
 
 You can access the KU Leuven Tier-2 either through ``login.hpc.kuleuven.be`` or
 ``login-genius.hpc.kuleuven.be``.

--- a/source/leuven/tier2_hardware/tier2_login_nodes.rst
+++ b/source/leuven/tier2_hardware/tier2_login_nodes.rst
@@ -18,7 +18,7 @@ Login infrastructure
 .. note::
 
    Restrictions apply for direct login using SSH. Make sure to read the
-   section on :ref:`access restrictions <auth_location_access_restrictions>`
+   section on :ref:`access restrictions <location_access_restrictions>`
    before proceeding.
 
 You can access the KU Leuven Tier-2 either through ``login.hpc.kuleuven.be`` or

--- a/source/leuven/tier2_hardware/tier2_login_nodes.rst
+++ b/source/leuven/tier2_hardware/tier2_login_nodes.rst
@@ -15,8 +15,12 @@ machines is possible
 Login infrastructure
 --------------------
 
-Direct login using SSH is possible to all login infrastructure, taking into
-account :ref:`access restrictions <location_access_restrictions>`.
+.. note::
+
+   Restrictions apply for direct login using SSH. Make sure to read the
+   section on :ref:`access restrictions <auth_location_access_restrictions>`
+   before proceeding.
+
 You can access the KU Leuven Tier-2 either through ``login.hpc.kuleuven.be`` or
 ``login-genius.hpc.kuleuven.be``. This will loadbalance your connection to one
 of the 4 Genius login nodes.


### PR DESCRIPTION
The "MFA login" page was not updated as part of https://github.com/hpcleuven/VscDocumentation/pull/560, this provides a small fix to rectify that.