### PR TITLE
remove irods-setup command

### DIFF
--- a/source/data/tier1data/clients/icommands.rst
+++ b/source/data/tier1data/clients/icommands.rst
@@ -140,16 +140,6 @@ Ubuntu/Debian (local machines):
 
 - Click the authentication link displayed in your terminal and complete the steps on https://auth.vscentrum.be/.
 
-Alternatively, you can use one of the following commands to log in from HPC nodes: 
-
-- On HPC clusters of the KU Leuven, use the command ``irods-setup --zone <zone> | bash``.  
-  This command can also be used at the beginning of your job script to authenticate.
-  This is especially recommended for long running jobs, since if they spend a lot of time in the queue and a long time running, this may exceed the standard 7 day authentication.  
-
-- On other HPC clusters in Flanders, you can log in with ``ssh login.hpc.kuleuven.be irods-setup --zone <zone> | bash``.  
-  This command can currently not be included in job scripts, since it requires interaction from the user.  
-
-For most users, the ``<zone>`` will be the default zone 'vsc'.
 
 ************
 Getting help


### PR DESCRIPTION
This command was deprecated shortly after the introduction of PAM-interactive authentication.
Users should use iron instead.