### PR TITLE
Update note about turbo frequencies on Rocky 8

### DIFF
--- a/source/leuven/wice_advanced_guide.rst
+++ b/source/leuven/wice_advanced_guide.rst
@@ -180,6 +180,6 @@ Turbo frequency
 ---------------
 
 With wICE running on Rocky Linux 9, the CPU cores are no longer able to reach the maximal
-('turbo') frequency. Compared to nodes with Rocky 8, you may therefore see somewhat lower
-performance if only a few cores are active while the other cores are idling. This issue is
-still being investigated.
+('turbo') frequency. Compared to wICE nodes running on Rocky 8 (which was the case before
+February 2026), you may therefore see somewhat lower performance if only a few cores are
+active while the other cores are idling. This issue is still being investigated.


### PR DESCRIPTION
This PR updates the note about the difference in turbo frequencies on Rocky 9 and Rocky 8, so it is clear there no longer are nodes on Rocky 8.