### PR TITLE
Add link to sofia portal

### DIFF
--- a/source/_static/css/vsc.css
+++ b/source/_static/css/vsc.css
@@ -157,6 +157,16 @@ html[data-theme="dark"] a.nav-link:hover img.icon-link-image {
     background: linear-gradient(to bottom, #FFCC2933, #FFCC2966);
 }
 
+/* sofia badge custom color */
+html[data-theme="light"] .sd-bg-sofia {
+    background-color: #003399;
+    color: white;
+}
+html[data-theme="dark"] .sd-bg-sofia {
+    background-color: #75b9e5;
+    color: black;
+}
+
 /* hide caption lable in code-blocks */
 .code-block-caption .caption-number { display: none; }
 /* line numbers in codeblocks on transparent column */

--- a/source/accounts/clusters_ssh_key.rst
+++ b/source/accounts/clusters_ssh_key.rst
@@ -17,6 +17,9 @@
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
-       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
+
+       |sofia|
+
+       * Tier-1 :ref:`sofia <sofia cluster>`

--- a/source/brussel/tier1_sofia.rst
+++ b/source/brussel/tier1_sofia.rst
@@ -1,3 +1,5 @@
+.. _sofia cluster:
+
 .. grid:: 2
    :class-container: bg-transparent
 
@@ -16,9 +18,6 @@
       .. image:: images/sofia-sun.png
          :width: 98%
          :class: bg-transparent
-
-
-.. _sofia cluster:
 
 sofia @ VUB-HPC
 ===============
@@ -140,8 +139,7 @@ or vice versa. Make sure your SSH keys are properly configured or forwarded.
 
   For resource-intensive interactive tasks, like software compilation, testing software or job scripts, etc.,
   please use an interactive job, preferentially on the ``zen5_vis`` partition,
-  either via ``salloc -p zen5_vis`` or in the future through the
-  :ref:`sofia_web_portal`.
+  either via ``salloc -p zen5_vis`` or through the :ref:`sofia_web_portal`.
 
 .. _sofia_login_nodes_host_keys:
 
@@ -176,7 +174,10 @@ The type of fingerprint that will be shown depends on the version and configurat
 Web portal
 **********
 
-The **sofia** web portal is not yet be available during the pilot phase.
+To access Tier-1 **sofia** you can also use the `Open On-Demand` web portal at
+https://portal.sofia.vub.be.
+
+You will need an active project in order to get access.
 
 More information about the usage of the web portal is available at :ref:`compute portal`.
 

--- a/source/brussel/tier1_sofia.rst
+++ b/source/brussel/tier1_sofia.rst
@@ -174,7 +174,7 @@ The type of fingerprint that will be shown depends on the version and configurat
 Web portal
 **********
 
-To access Tier-1 **sofia** you can also use the `Open On-Demand` web portal at
+To access Tier-1 **sofia** you can also use the `Open OnDemand` web portal at
 https://portal.sofia.vub.be.
 
 You will need an active project in order to get access.

--- a/source/compute/portal/index.rst
+++ b/source/compute/portal/index.rst
@@ -56,6 +56,8 @@ VSC clusters that support an Open OnDemand web portal:
        | Tier-2 :ref:`Anansi <Anansi cluster>`
        | Tier-2 :ref:`Hydra <Hydra cluster>`
 
+       |sofia|
+
        :fas:`circle-play` `sofia OnDemand`_
 
        | Tier-1 :ref:`sofia <sofia cluster>`

--- a/source/compute/portal/index.rst
+++ b/source/compute/portal/index.rst
@@ -56,10 +56,15 @@ VSC clusters that support an Open OnDemand web portal:
        | Tier-2 :ref:`Anansi <Anansi cluster>`
        | Tier-2 :ref:`Hydra <Hydra cluster>`
 
+       :fas:`circle-play` `sofia OnDemand`_
+
+       | Tier-1 :ref:`sofia <sofia cluster>`
+
 .. _KU Leuven OnDemand: https://ondemand.hpc.kuleuven.be/
 .. _UAntwerp OnDemand: https://portal.hpc.uantwerpen.be/
 .. _UGent OnDemand: https://login.hpc.ugent.be/
 .. _VUB OnDemand: https://portal.hpc.vub.be/
+.. _sofia OnDemand: https://portal.sofia.vub.be/
 
 You can log in using the credentials of your home institution or your VSC
 credentials. SSH keys are not required to use the web portal.

--- a/source/compute/portal/ondemand/desktop.rst
+++ b/source/compute/portal/ondemand/desktop.rst
@@ -22,9 +22,12 @@ VSC clusters that support the Desktop app:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
-       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
+
+       |sofia|
+
+       * Tier-1 :ref:`sofia <sofia cluster>`
 
 
 .. tip::

--- a/source/compute/portal/ondemand/desktop.rst
+++ b/source/compute/portal/ondemand/desktop.rst
@@ -22,6 +22,7 @@ VSC clusters that support the Desktop app:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
+       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
 

--- a/source/compute/portal/ondemand/desktop.rst
+++ b/source/compute/portal/ondemand/desktop.rst
@@ -82,6 +82,19 @@ For improved graphics performance, we recommend the following workflow:
 
             vglrun <executable>
 
+   .. tab-item:: sofia
+      :sync: sofia
+
+      #. Select the ``zen5_vis`` partition and request a GPU.
+      #. In the desktop environment, open a terminal window and load the
+         module of your graphical software.
+      #. Launch the executable with ``vglrun`` to enable hardware
+         acceleration:
+
+         .. code-block:: bash
+
+            vglrun <executable>
+
 Additional site-specific constraints are listed below.
 
 .. tab-set::
@@ -138,5 +151,10 @@ Additional site-specific constraints are listed below.
 
    .. tab-item:: VUB
       :sync: vub
+
+      (N/A)
+
+   .. tab-item:: sofia
+      :sync: sofia
 
       (N/A)

--- a/source/compute/portal/ondemand/files.rst
+++ b/source/compute/portal/ondemand/files.rst
@@ -16,7 +16,7 @@ modifying and creating files or directories are available as well.
       From the 'Files' menu, you can access your ``$VSC_HOME`` and ``$VSC_DATA``
       folders.
 
-   .. tab-item:: VUB
+   .. tab-item:: VUB/sofia
       :sync: vub
 
       From the 'Files' menu, you can access all ``$VSC_*`` folders available to

--- a/source/compute/portal/ondemand/files.rst
+++ b/source/compute/portal/ondemand/files.rst
@@ -16,8 +16,14 @@ modifying and creating files or directories are available as well.
       From the 'Files' menu, you can access your ``$VSC_HOME`` and ``$VSC_DATA``
       folders.
 
-   .. tab-item:: VUB/sofia
+   .. tab-item:: VUB
       :sync: vub
+
+      From the 'Files' menu, you can access all ``$VSC_*`` folders available to
+      you.
+
+   .. tab-item:: sofia
+      :sync: sofia
 
       From the 'Files' menu, you can access all ``$VSC_*`` folders available to
       you.

--- a/source/compute/portal/ondemand/interactive-apps.rst
+++ b/source/compute/portal/ondemand/interactive-apps.rst
@@ -106,7 +106,7 @@ job will be queued.
          sharing your sensitive data, sources and information by all means.
 
 
-   .. tab-item:: VUB/sofia
+   .. tab-item:: VUB
       :sync: vub
 
       .. list-table:: Shared resources (part 2)
@@ -119,11 +119,24 @@ job will be queued.
            - Specify the working directory for your app, or use the handy
              ``Select Path`` button below the text field to select it from a
              file browser.
-         * - Account (**sofia**)
+
+   .. tab-item:: sofia
+      :sync: sofia
+
+      .. list-table:: Shared resources (part 2)
+         :header-rows: 1
+         :widths: 20 80
+
+         * - Resource
+           - Description
+         * - Working Directory
+           - Specify the working directory for your app, or use the handy
+             ``Select Path`` button below the text field to select it from a
+             file browser.
+         * - Account
            - Select the credit account you want to deduct the credits from.  The
              accounts associated with your VSC-id will be displayed in a
              drop-down menu.
-
 
 .. _choosing_your_resources:
 
@@ -190,6 +203,18 @@ your job resources:
       For light-weight (testing) work, we recommend using the :ref:`Anansi
       cluster`, which also contains shared GPUs for improved rendering
       performance.
+
+      .. note::
+
+         The allocated CPU memory in your session is fixed at a default value
+         per core.  To get more memory, just request additional cores in the
+         resources form.
+
+   .. tab-item:: sofia
+      :sync: sofia
+
+      For light-weight (testing) work, we recommend using the zen5_vis
+      partition.
 
       .. note::
 

--- a/source/compute/portal/ondemand/interactive-apps.rst
+++ b/source/compute/portal/ondemand/interactive-apps.rst
@@ -106,7 +106,7 @@ job will be queued.
          sharing your sensitive data, sources and information by all means.
 
 
-   .. tab-item:: VUB
+   .. tab-item:: VUB/sofia
       :sync: vub
 
       .. list-table:: Shared resources (part 2)
@@ -119,6 +119,10 @@ job will be queued.
            - Specify the working directory for your app, or use the handy
              ``Select Path`` button below the text field to select it from a
              file browser.
+         * - Account (**sofia**)
+           - Select the credit account you want to deduct the credits from.  The
+             accounts associated with your VSC-id will be displayed in a
+             drop-down menu.
 
 
 .. _choosing_your_resources:

--- a/source/compute/portal/ondemand/jupyterlab.rst
+++ b/source/compute/portal/ondemand/jupyterlab.rst
@@ -110,9 +110,12 @@ VSC clusters that support different Jupyter kernels:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
-       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
+
+       |sofia|
+
+       * Tier-1 :ref:`sofia <sofia cluster>`
 
 The following table shows the kernels available in JupyterLab and the
 corresponding modules that have to be loaded to enable them:
@@ -313,9 +316,12 @@ VSC clusters that support the 'Software Modules' Lab extension:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
-       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
+
+       |sofia|
+
+       * Tier-1 :ref:`sofia <sofia cluster>`
 
 The 'Software Modules' Lab extension is enabled by default in your JupyterLab
 session.  You can load software modules from the tab with a *hexagon* icon on
@@ -373,9 +379,12 @@ VSC clusters that support the matplotlib Lab extension:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
-       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
+
+       |sofia|
+
+       * Tier-1 :ref:`sofia <sofia cluster>`
 
 To activate the Lab extension in your notebook, use the ``%matplotlib ipympl`` or
 ``%matplotlib widget`` magic command. To ensure your plot is always shown, make
@@ -403,9 +412,12 @@ VSC clusters that support the Dask Lab extension:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
-       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
+
+       |sofia|
+
+       * Tier-1 :ref:`sofia <sofia cluster>`
 
 #. In the resources form, tick the 'Load the dask module' checkbox to make sure
    the Dask Lab extension is loaded before starting JupyterLab.
@@ -452,9 +464,12 @@ VSC clusters that support the Bash kernel extension:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
-       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
+
+       |sofia|
+
+       * Tier-1 :ref:`sofia <sofia cluster>`
 
 By default, the 'Bash' kernel is loaded in your environment, starting from the 2023a toolchain.
 To use it in a notebook, you need to choose the 'Bash' or 'Python 3 (ipykernel)' jupyter  kernels

--- a/source/compute/portal/ondemand/jupyterlab.rst
+++ b/source/compute/portal/ondemand/jupyterlab.rst
@@ -28,6 +28,17 @@ environment (as elaborated below).
       (default = ``~/.jupyter/jupyter_server_config.py``), this config will take
       priority over your 'Working directory' in the resources form.
 
+   .. tab-item:: sofia
+      :sync: sofia
+
+      The top-level notebook directory is the selected 'Working directory' in
+      the resources form. Note however, if you have set ``c.ServerApp.root_dir``
+      in your `Jupyter configuration file
+      <https://jupyter-server.readthedocs.io/en/stable/other/full-config.html>`_
+      (default = ``~/.jupyter/jupyter_server_config.py``), this config will take
+      priority over your 'Working directory' in the resources form.
+
+
 
 .. _jupyterlab_pure_module_env:
 
@@ -62,6 +73,15 @@ listed Python module).
       - ``Scipy-bundle`` - data science packages like ``scipy``, ``numpy``, ``pandas``
       - ``matplotlib`` - plotting library and :ref:`matplotlib_lab_extension`
 
+   .. tab-item:: sofia
+      :sync: sofia
+
+      A large number of widely used Python packages are already available by
+      default. The following modules are always loaded with JupyterLab:
+
+      - ``Python-bundle-PyPI`` - packages for general usage
+      - ``Scipy-bundle`` - data science packages like ``scipy``, ``numpy``, ``pandas``
+      - ``matplotlib`` - plotting library and :ref:`matplotlib_lab_extension`
 
 If you need additional Python packages, you can load extra modules with Python
 packages via ``module load`` commands in the 'Pre-run Scriptlet' of the
@@ -90,6 +110,7 @@ VSC clusters that support different Jupyter kernels:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
+       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
 
@@ -292,6 +313,7 @@ VSC clusters that support the 'Software Modules' Lab extension:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
+       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
 
@@ -351,6 +373,7 @@ VSC clusters that support the matplotlib Lab extension:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
+       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
 
@@ -380,6 +403,7 @@ VSC clusters that support the Dask Lab extension:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
+       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
 
@@ -428,6 +452,7 @@ VSC clusters that support the Bash kernel extension:
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
+       * Tier-1 :ref:`sofia <sofia cluster>`
        * Tier-2 :ref:`Anansi <Anansi cluster>`
        * Tier-2 :ref:`Hydra <Hydra cluster>`
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -311,6 +311,9 @@ rst_prolog += """
 .. |UG| replace:: :bdg-secondary:`UGent`
 .. |UH| replace:: :bdg-info:`UHasselt`
 .. |VUB| replace:: :bdg-primary:`VUB`
+.. |sofia| raw:: html
+
+   <span class="sd-badge sd-bg-sofia">sofia</span>
 """
 ### Links used multiple times across the documentation ###
 # Links to VSC and VSC sites


### PR DESCRIPTION
Add very short Web portal section for **sofia** production.

Also fixes the link to the **sofia** docs page to open at the top (above the logos) instead of at the first section title.