### PR TITLE
Add sofia mfa login info

### DIFF
--- a/source/accounts/clusters_mfa.rst
+++ b/source/accounts/clusters_mfa.rst
@@ -8,3 +8,9 @@
        * Tier-2 :ref:`wICE <wICE hardware>`
        * Tier-2 :ref:`Mindwell <mindwell hardware>`
 
+    .. grid-item-card:: |vub|
+       :columns: 12 4 4 4
+       
+       |sofia|
+
+       * Tier-1 :ref:`sofia <sofia cluster>`

--- a/source/accounts/mfa_login.rst
+++ b/source/accounts/mfa_login.rst
@@ -15,6 +15,7 @@ VSC clusters:
 Login to Open OnDemand
 ----------------------
 
+|KULUH|
 Users from all VSC sites can access the Open OnDemand portal at KU Leuven site.
 For that, proceed to the :ref:`Open OnDemand portal <ood>`.
 If you are affiliated with KU Leuven, click on the KU Leuven logo.
@@ -48,20 +49,36 @@ You can acquire such an SSH certificate as follows:
   * macOS: use the default :ref:`OpenSSH agent`
   * Linux: use the default :ref:`OpenSSH agent`
 
-* Connect to either the cluster's login node or to ``firewall.vscentrum.be``
-  with your terminal application of choice and with agent forwarding enabled.
-  With e.g. OpenSSH you can do:
+.. tab-set::
+   :sync-group: vsc-sites
 
-  .. code-block:: bash
+   .. tab-item:: KU Leuven/UHasselt
+      :sync: kuluh
 
-     ssh -A vsc98765@login.hpc.kuleuven.be
-     # or
-     ssh -A vsc98765@firewall.vscentrum.be
+      * Connect to either the cluster's login node or to ``firewall.vscentrum.be``
+        with your terminal application of choice and with agent forwarding enabled.
+        With e.g. OpenSSH you can do:
 
-  PuTTY users can find the agent forwarding option under the
-  'Connection -> SSH -> Auth' tab.
-  OpenSSH users may also automatically
-  enable agent forwarding in their :ref:`SSH config file <ssh_config>`.
+        .. code-block:: bash
+
+           ssh -A vsc98765@login.hpc.kuleuven.be
+           # or
+           ssh -A vsc98765@firewall.vscentrum.be
+
+   .. tab-item:: sofia
+      :sync: sofia
+
+      * Connect to ``firewall.vscentrum.be`` with your terminal application of
+        choice and with agent forwarding enabled. With e.g. OpenSSH you can do:
+
+        .. code-block:: bash
+
+           ssh -A vsc98765@firewall.vscentrum.be
+
+PuTTY users can find the agent forwarding option under the
+'Connection -> SSH -> Auth' tab.
+OpenSSH users may also automatically
+enable agent forwarding in their :ref:`SSH config file <ssh_config>`.
 
 * You will then be shown a URL which you will need to open in a browser:
 
@@ -83,13 +100,14 @@ You can acquire such an SSH certificate as follows:
 
 * You will be forwarded to the Identity Provider (IdP) of your institute,
   and you need to login in a usual way using your registered credentials.
-  For KU Leuven users, the page looks like the following:
+
+  |kuluh| For KU Leuven users, the page looks like the following:
 
   .. _idp_page:
   .. figure:: mfa_login/idp_page.PNG
      :alt: idp_page
 
-* If you are already connected to the internal network, then you will be only asked to
+* |kuluh| If you are already connected to the internal network, then you will be only asked to
   identify yourself with the MFA authenticator app on your personal phone:
 
   .. _reauthenticate_phone:

--- a/source/brussel/tier1_sofia.rst
+++ b/source/brussel/tier1_sofia.rst
@@ -125,7 +125,7 @@ such an SSH certificate via multi-factor authentication as described
 
 .. note::
    Alternatively, if you are not inside the Flemish university network you can ``ssh`` into **sofia**
-   from the login nodes of any Tier-2 cluster. Do not forget to set up your SSH keys there or 
+   from the login nodes of any Tier-2 cluster. Do not forget to set up your SSH keys there or
    to forward your SSH agent.
 
 More general information about SSH login is available in the

--- a/source/brussel/tier1_sofia.rst
+++ b/source/brussel/tier1_sofia.rst
@@ -112,12 +112,21 @@ Login nodes (SSH)
 *****************
 
 You can use SSH to connect to the login nodes of the Tier-1 **sofia** cluster
-with your VSC account.  From within the Flemish university network, use your
-VSC-id to connect to ``sofia.hpc.vub.be``.
+with your VSC account, using your VSC-id to connect to ``login.sofia.vub.be``.
+
+.. code-block:: bash
+
+   ssh <VSC-id>@login.sofia.vub.be
+
+From within the Flemish university network, you can connect directly using your SSH key.
+From outside the university network, only SSH certificates are accepted. You can set up
+such an SSH certificate via multi-factor authentication as described
+`here <https://docs.vscentrum.be/accounts/mfa_login.html#connecting-with-an-ssh-agent>`__.
 
 .. note::
-   If you are not inside the Flemish university network you can ``ssh`` into **sofia** from the login nodes
-   of any Tier-2 cluster. Do not forget to set up your SSH keys there or to forward your SSH agent.
+   Alternatively, if you are not inside the Flemish university network you can ``ssh`` into **sofia**
+   from the login nodes of any Tier-2 cluster. Do not forget to set up your SSH keys there or 
+   to forward your SSH agent.
 
 More general information about SSH login is available in the
 :ref:`terminal

--- a/source/brussel/tier1_sofia.rst
+++ b/source/brussel/tier1_sofia.rst
@@ -125,7 +125,7 @@ such an SSH certificate via multi-factor authentication as described
 
 .. note::
    Alternatively, if you are not inside the Flemish university network you can ``ssh`` into **sofia**
-   from the login nodes of any Tier-2 cluster. Do not forget to set up your SSH keys there or
+   from the login nodes of any VSC Tier-2 cluster. Do not forget to set up your SSH keys there or
    to forward your SSH agent.
 
 More general information about SSH login is available in the
@@ -200,6 +200,13 @@ Similar to *Hortense*, the user’s ``$HOME`` directory is located on the scratc
 file system and is distinct from the user’s ``$VSC_HOME``.  The advantage of
 this setup is that **sofia** remains accessible even if the user’s home
 institution cluster is down.
+
+$VSC_HOME and $VSC_DATA
+***********************
+
+``$VSC_HOME`` and ``$VSC_DATA`` are not directly accessible on **sofia**.
+We highly recommend using :ref:`Globus <sofia_scratch_globus>`
+for file transfer between **sofia** and Tier-2 storage.
 
 Node-local scratch and in-memory storage
 ****************************************

--- a/source/brussel/tier1_sofia.rst
+++ b/source/brussel/tier1_sofia.rst
@@ -201,14 +201,6 @@ file system and is distinct from the user’s ``$VSC_HOME``.  The advantage of
 this setup is that **sofia** remains accessible even if the user’s home
 institution cluster is down.
 
-$VSC_HOME and $VSC_DATA
-***********************
-
-The :ref:`storage hardware`, specifically ``$VSC_HOME`` and ``$VSC_DATA``, is accessible, but **only on the
-login nodes**, and **only during the pilot phase**. These will be removed when
-the pilot phase concludes. We highly recommend using :ref:`Globus <sofia_scratch_globus>`
-for file transfer between **sofia** and Tier-2 storage.
-
 Node-local scratch and in-memory storage
 ****************************************
 

--- a/source/compute/tier1.rst
+++ b/source/compute/tier1.rst
@@ -15,6 +15,8 @@
     .. grid-item-card:: |VUB|
        :columns: 12 4 4 4
 
+       |sofia|
+
        * Tier-1 :ref:`sofia <sofia cluster>`
 
 .. toctree::


### PR DESCRIPTION
Host has become `login.sofia.vub.be`. Mention certificate is needed from outside university network. 

Inject sofia information to mfa_login page. Could be cleaned up a bit more at a later date.