### PR TITLE
Add FileZilla not on sofia

### DIFF
--- a/source/accounts/mfa_login.rst
+++ b/source/accounts/mfa_login.rst
@@ -150,14 +150,6 @@ SSH Client name                        Purpose              Operating System
 :ref:`FileZilla <FileZilla>`           file transfer        Windows, Linux, macOS
 ====================================== ==================== =====================
 
-.. warning::
-
-   |sofia| Connecting to Tier-1 **sofia** using an MFA certificate held in
-   an SSH Agent does not work in the FileZilla client.
-
-   We recommend using the :ref:`Globus platform <globus platform>` instead.
-
-
 .. _mfa quick start:
 
 Connecting without an SSH agent

--- a/source/accounts/mfa_login.rst
+++ b/source/accounts/mfa_login.rst
@@ -150,6 +150,13 @@ SSH Client name                        Purpose              Operating System
 :ref:`FileZilla <FileZilla>`           file transfer        Windows, Linux, macOS
 ====================================== ==================== =====================
 
+.. warning::
+
+   |sofia| Connecting to Tier-1 **sofia** using an MFA certificate held in
+   an SSH Agent does not work in the FileZilla client.
+
+   We recommend using the :ref:`Globus platform <globus platform>` instead.
+
 
 .. _mfa quick start:
 

--- a/source/accounts/mfa_login.rst
+++ b/source/accounts/mfa_login.rst
@@ -150,6 +150,7 @@ SSH Client name                        Purpose              Operating System
 :ref:`FileZilla <FileZilla>`           file transfer        Windows, Linux, macOS
 ====================================== ==================== =====================
 
+
 .. _mfa quick start:
 
 Connecting without an SSH agent

--- a/source/data/transfer/filezilla.rst
+++ b/source/data/transfer/filezilla.rst
@@ -10,6 +10,11 @@ transfer files to and from your VSC account on the clusters.
 
 You can `download FileZilla`_ from the `FileZilla project page`_.
 
+.. note::
+
+   |sofia| Connecting to **sofia** using an MFA certificate held in an
+   SSH agent is not possible through FileZilla.
+
 Prerequisites
 =============
 

--- a/source/data/transfer/filezilla.rst
+++ b/source/data/transfer/filezilla.rst
@@ -10,10 +10,13 @@ transfer files to and from your VSC account on the clusters.
 
 You can `download FileZilla`_ from the `FileZilla project page`_.
 
-.. note::
+.. warning::
 
-   |sofia| Connecting to **sofia** using an MFA certificate held in an
-   SSH agent is not possible through FileZilla.
+   |sofia| Connecting to Tier-1 **sofia** using an MFA certificate held in
+   an SSH Agent does not work in the FileZilla client.
+
+   We recommend using the :ref:`Globus platform <globus platform>` instead.
+
 
 Prerequisites
 =============


### PR DESCRIPTION
Adds a note to the FileZilla data-transfer page that authenticating to
Tier-1 sofia with an SSH-agent-held MFA certificate does not currently
work in FileZilla.

FileZilla fails to authenticate to **sofia**'s login nodes with an MFA certificate held in an SSH
agent. They are by default ignored since their type is unknown.
But still fails in FileZilla when checking the option: "Allow SSH agent keys of unknown
type".

**sofia** excludes the legacy
`ssh-rsa`/`ssh-rsa-cert-v01@openssh.com` algorithm name. FileZilla's SSH
library upgrades a *bare* RSA key to a modern SHA2 algorithm name before
offering it, but does not apply the same upgrade to RSA *certificates*,
so it offers the certificate under the legacy name and sofia's sshd
rejects it before ever checking the signature.

Tested against a certificate that works fine with OpenSSH client, also this cert in FileZilla (with the unknown type workaround) works fine for the KU Leuven T2, so it is **sofia** specific.